### PR TITLE
Add IP Address Validation to PR Workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -188,6 +188,60 @@ jobs:
           print("Navigation structure check completed successfully")
           EOF
 
+  ip-validation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate IP addresses
+        run: |
+          python3 << 'EOF'
+          import re
+          import ipaddress
+          import glob
+          import sys
+          
+          def validate_ipv4(ip):
+              try:
+                  addr = ipaddress.IPv4Address(ip)
+                  return str(addr) == ip
+              except:
+                  return False
+          
+          def validate_ipv6(ip):
+              try:
+                  addr = ipaddress.IPv6Address(ip)
+                  return str(addr) == ip.lower() and '::' not in ip.replace('::', ':::')
+              except:
+                  return False
+          
+          errors = []
+          ipv4_pattern = r'\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b'
+          ipv6_pattern = r'\b(?:[0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}\b'
+          
+          for file in glob.glob('content/**/*.md', recursive=True):
+              if 'community/conventions.md' in file:
+                  continue
+              
+              with open(file, 'r') as f:
+                  content = f.read()
+              
+              for match in re.finditer(ipv4_pattern, content):
+                  ip = match.group()
+                  if not validate_ipv4(ip):
+                      errors.append(f"{file}: Invalid IPv4 '{ip}'")
+              
+              for match in re.finditer(ipv6_pattern, content):
+                  ip = match.group()
+                  if ':' in ip and not validate_ipv6(ip):
+                      errors.append(f"{file}: Invalid IPv6 '{ip}' (use lowercase, compressed format)")
+          
+          if errors:
+              for error in errors:
+                  print(error)
+              sys.exit(1)
+          print("IP address validation passed")
+          EOF
+
   meta-check:
     runs-on: ubuntu-latest
     continue-on-error: true


### PR DESCRIPTION
# Description

### Changes
- Added `ip-validation` job to `.github/workflows/pr-validation.yml`
- Validates IPv4 addresses in dotted decimal format
- Validates IPv6 addresses against RFC5952 standards (lowercase, compressed zeros)
- Excludes `content/community/conventions.md` from validation

### Implementation
- Uses Python `ipaddress` module for validation
- Regex patterns to extract IP addresses from markdown files
- Fails PR if invalid IP addresses are found

### Testing
- Ran validation on current repository state - all checks pass

Fixes #24

# Checklist:

- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.