### PR TITLE
Add Documentation IP Range Validation

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -200,6 +200,15 @@ jobs:
           import glob
           import sys
           
+          doc_ranges = [
+              '192.0.2.0/24', '198.51.100.0/24', '203.0.113.0/24', '233.252.0.0/24',
+              '2001:db8::/32', '3fff::/20',
+              '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16',
+              '169.254.0.0/16', '127.0.0.0/8', '224.0.0.0/4', '240.0.0.0/4', '100.64.0.0/10',
+              'fe80::/10', 'fc00::/7', '::1/128', 'ff00::/8', '::/128', '::ffff:0:0/96'
+          ]
+          doc_networks = [ipaddress.ip_network(r) for r in doc_ranges]
+          
           def validate_ipv4(ip):
               try:
                   addr = ipaddress.IPv4Address(ip)
@@ -214,9 +223,16 @@ jobs:
               except:
                   return False
           
+          def is_doc_ip(ip):
+              try:
+                  addr = ipaddress.ip_address(ip)
+                  return any(addr in net for net in doc_networks)
+              except:
+                  return False
+          
           errors = []
-          ipv4_pattern = r'\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}\b'
-          ipv6_pattern = r'\b(?:[0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}\b'
+          ipv4_pattern = r'\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}(?:/[0-9]{1,2})?\b'
+          ipv6_pattern = r'\b(?:[0-9a-fA-F]{0,4}:){2,7}[0-9a-fA-F]{0,4}(?:/[0-9]{1,3})?\b'
           
           for file in glob.glob('content/**/*.md', recursive=True):
               if 'community/conventions.md' in file:
@@ -226,14 +242,20 @@ jobs:
                   content = f.read()
               
               for match in re.finditer(ipv4_pattern, content):
-                  ip = match.group()
+                  ip_cidr = match.group()
+                  ip = ip_cidr.split('/')[0]
                   if not validate_ipv4(ip):
                       errors.append(f"{file}: Invalid IPv4 '{ip}'")
+                  elif not is_doc_ip(ip):
+                      errors.append(f"{file}: Non-documentation IPv4 '{ip_cidr}' - use approved ranges")
               
               for match in re.finditer(ipv6_pattern, content):
-                  ip = match.group()
+                  ip_cidr = match.group()
+                  ip = ip_cidr.split('/')[0]
                   if ':' in ip and not validate_ipv6(ip):
                       errors.append(f"{file}: Invalid IPv6 '{ip}' (use lowercase, compressed format)")
+                  elif ':' in ip and not is_doc_ip(ip):
+                      errors.append(f"{file}: Non-documentation IPv6 '{ip_cidr}' - use approved ranges")
           
           if errors:
               for error in errors:


### PR DESCRIPTION
# Description

### Changes
- Enhanced IP validation to check against approved documentation ranges
- Added comprehensive allowlist of private/documentation IP ranges
- Support for CIDR notation validation
- Flags any real public IP addresses in documentation

### Approved Ranges
**IPv4:** RFC1918 private, documentation (TEST-NET), link-local, loopback, multicast, reserved, carrier-grade NAT
**IPv6:** Documentation, link-local, unique local, loopback, multicast, unspecified, IPv4-mapped

### Implementation
- Uses Python `ipaddress` module for subnet calculations
- Validates both individual IPs and CIDR blocks
- Comprehensive range checking to minimize false positives

### Benefits
- Prevents accidental exposure of real IP addresses
- Ensures consistent use of appropriate documentation ranges
- Maintains security best practices in documentation

Fixes #25

# Checklist:

- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.