### PR TITLE
Add Markdown Preview for PR Reviews

### DIFF
--- a/.github/workflows/markdown-preview.yml
+++ b/.github/workflows/markdown-preview.yml
@@ -1,0 +1,64 @@
+name: Markdown Preview
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'content/**/*.md'
+
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generate markdown preview
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            
+            const changedFiles = execSync(`git diff --name-only origin/${{ github.base_ref }}...HEAD`)
+              .toString().trim().split('\n').filter(f => f.endsWith('.md'));
+            
+            for (const file of changedFiles) {
+              const diffOutput = execSync(`git diff origin/${{ github.base_ref }}...HEAD -- "${file}"`)
+                .toString();
+              
+              const addedLines = diffOutput.split('\n')
+                .filter(line => line.startsWith('+') && !line.startsWith('+++'))
+                .map(line => line.substring(1));
+              
+              const removedLines = diffOutput.split('\n')
+                .filter(line => line.startsWith('-') && !line.startsWith('---'))
+                .map(line => line.substring(1));
+              
+              const totalChanges = addedLines.length + removedLines.length;
+              
+              if (totalChanges > 50) {
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: `## 📄 Large Changes Detected in \`${file}\`\n\nThis file has ${totalChanges} lines of changes, which may be difficult to review.\n\n**Recommendation:** Consider splitting this PR into smaller, focused changes to:\n- Improve review quality\n- Reduce cognitive load\n- Enable more thorough feedback\n\nIf these changes must be together, please explain why in the PR description.`
+                });
+              } else if (addedLines.length > 0 || removedLines.length > 0) {
+                let body = `## 📖 Preview: \`${file}\`\n\n`;
+                
+                if (addedLines.length > 0) {
+                  body += `### New Content\n\n${addedLines.join('\n')}\n\n`;
+                }
+                
+                if (removedLines.length > 0) {
+                  body += `<details>\n<summary>👁️ Show replaced content</summary>\n\n${removedLines.join('\n')}\n\n</details>`;
+                }
+                
+                await github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: body
+                });
+              }
+            }


### PR DESCRIPTION
# Description

### Changes
- **New workflow** `markdown-preview.yml` that generates rendered previews
- **Shows new content** prominently with proper markdown rendering
- **Collapsible section** for replaced/removed content
- **Split recommendation** for PRs with >50 total line changes

### Benefits
- **Better review experience** - see rendered content instead of raw markdown diffs
- **Easier formatting review** - spot issues with headings, lists, links immediately  
- **Reduced context switching** - no need to toggle between diff and file view
- **Focused reviews** - new content prominent, old content accessible but not distracting

### Implementation
- Triggers only on markdown file changes to avoid noise
- Uses GitHub's native markdown rendering in comments
- Counts both added and removed lines for split threshold
- Provides clean visual separation between new and old content

# Checklist:

- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.