### PR TITLE
Add Issue Notifications and Enhance Slack Messages

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -36,3 +36,9 @@ jobs:
             status: "${{ job.status }}"
             repo: "${{ github.repository }}"
             user: "${{ github.actor }}"
+            commit_message: "${{ github.event.head_commit.message }}"
+            commit_sha: "${{ github.sha }}"
+            branch: "${{ github.ref_name }}"
+            commit_url: "${{ github.event.head_commit.url }}"
+            pages_url: "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
+

--- a/.github/workflows/issue-notifications.yml
+++ b/.github/workflows/issue-notifications.yml
@@ -1,0 +1,25 @@
+name: Issue Notifications
+
+on:
+  issues:
+    types: [opened, closed, reopened]
+
+jobs:
+  notify-slack:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send issue notification to Slack
+        uses: slackapi/slack-github-action@v2.0.0
+        with:
+          webhook: ${{ secrets.SLACK_WEBHOOK_URL_ISSUES }}
+          webhook-type: webhook-trigger
+          payload: |
+            event_type: "issue"
+            action: "${{ github.event.action }}"
+            issue_title: "${{ github.event.issue.title }}"
+            issue_number: "${{ github.event.issue.number }}"
+            issue_url: "${{ github.event.issue.html_url }}"
+            user: "${{ github.event.issue.user.login }}"
+            repo: "${{ github.repository }}"
+            labels: "${{ toJson(github.event.issue.labels.*.name) }}"
+            assignees: "${{ toJson(github.event.issue.assignees.*.login) }}"


### PR DESCRIPTION
# Description

### Changes
- **New workflow** `issue-notifications.yml` for GitHub issue events (opened, closed, reopened)
- **Enhanced deployment notifications** with commit details, branch info, and direct links
- **Consistent secret naming** using `SLACK_WEBHOOK_URL_ISSUES` pattern

### Deployment Notifications Now Include
- Commit message and SHA
- Branch name and commit URL
- Direct link to deployed GitHub Pages site
- User who triggered the deployment

### Issue Notifications Include
- Issue title, number, and URL
- Reporter, labels, and assignees
- Action type (opened/closed/reopened)
- Repository context

### Setup Required
- Add `SLACK_WEBHOOK_URL_ISSUES` secret to GitHub repository
- Configure corresponding Slack Workflow with provided template
- Both workflows use webhook triggers for flexibility

### Benefits
- **Better context** in Slack notifications
- **Actionable information** with direct links
- **Separate channels** for deployments vs issues
- **Consistent notification patterns**
# Checklist:

- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.