### PR TITLE
fix: enable PR validation workflows for external contributors

### DIFF
--- a/.github/workflows/pr-guidelines.yml
+++ b/.github/workflows/pr-guidelines.yml
@@ -3,7 +3,7 @@ name: PR Guidelines Check
 on:
   pull_request_target:
     branches: [main, master]
-    types: [opened, synchronize]
+    types: [opened, synchronize, reopened]
 
 jobs:
   check-guidelines:

--- a/.github/workflows/pr-guidelines.yml
+++ b/.github/workflows/pr-guidelines.yml
@@ -1,7 +1,7 @@
 name: PR Guidelines Check
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main, master]
     types: [opened, synchronize, reopened]
 

--- a/.github/workflows/pr-guidelines.yml
+++ b/.github/workflows/pr-guidelines.yml
@@ -1,7 +1,7 @@
 name: PR Guidelines Check
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main, master]
     types: [opened, synchronize]
 

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,7 +1,7 @@
 name: PR Validation
 
 on:
-  pull_request:
+  pull_request_target:
     branches: [main, master]
     paths:
       - 'content/**'
@@ -28,6 +28,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: DavidAnson/markdownlint-cli2-action@v16
         with:
           globs: 'content/**/*.md'
@@ -38,6 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - uses: ./.github/actions/setup-mkdocs
       - name: Build MkDocs site
@@ -47,6 +50,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'
@@ -58,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: streetsidesoftware/cspell-action@v6
         with:
           files: 'content/**/*.md'
@@ -67,6 +74,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: ibiqlik/action-yamllint@v3
         with:
           file_or_dir: mkdocs.yml
@@ -76,6 +85,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Check file naming conventions
         run: |
           # Check for spaces in filenames
@@ -95,6 +106,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Check image optimization
         run: |
           # Find large images (>500KB)
@@ -116,6 +129,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
@@ -136,6 +151,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Validate navigation structure
         run: |
           # Check that all markdown files are referenced in mkdocs.yml
@@ -192,6 +209,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: Validate IP addresses
         run: |
           python3 << 'EOF'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,7 +1,7 @@
 name: PR Validation
 
 on:
-  pull_request_target:
+  pull_request:
     branches: [main, master]
     types: [opened, synchronize, reopened]
     paths:
@@ -29,8 +29,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: DavidAnson/markdownlint-cli2-action@v16
         with:
           globs: 'content/**/*.md'
@@ -41,7 +39,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
       - uses: ./.github/actions/setup-mkdocs
       - name: Build MkDocs site
@@ -51,8 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'
@@ -64,8 +59,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: streetsidesoftware/cspell-action@v6
         with:
           files: 'content/**/*.md'
@@ -75,8 +68,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: ibiqlik/action-yamllint@v3
         with:
           file_or_dir: mkdocs.yml
@@ -86,8 +77,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Check file naming conventions
         run: |
           # Check for spaces in filenames
@@ -107,8 +96,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Check image optimization
         run: |
           # Find large images (>500KB)
@@ -130,8 +117,6 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
@@ -152,8 +137,6 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Validate navigation structure
         run: |
           # Check that all markdown files are referenced in mkdocs.yml
@@ -210,8 +193,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Validate IP addresses
         run: |
           python3 << 'EOF'

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -3,6 +3,7 @@ name: PR Validation
 on:
   pull_request_target:
     branches: [main, master]
+    types: [opened, synchronize, reopened]
     paths:
       - 'content/**'
       - 'mkdocs.yml'


### PR DESCRIPTION
# 📝 Description

# Fix PR Validation for External Contributors

## Problem
PR validation workflows (`pr-validation.yml` and `pr-guidelines.yml`) required manual approval for external contributors, defeating the purpose of automated checks.

## Solution
- Changed trigger from `pull_request` to `pull_request_target`
- Added explicit PR branch checkout using `ref: ${{ github.event.pull_request.head.sha }}`
- Maintains security by running workflow code from target branch while validating PR content

## Impact
- ✅ Validation workflows now run automatically for all contributors
- ✅ No manual approval required for external PRs
- ✅ Security maintained (workflow code comes from main branch)
- ✅ Immediate feedback for contributors

Fixes the workflow approval bottleneck while preserving security.

## 🔄 Type of Change
- [ ] New content
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing
- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [X] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.