### PR TITLE
fix: add issues write permission for PR comment creation

### DIFF
--- a/.github/workflows/pr-guidelines.yml
+++ b/.github/workflows/pr-guidelines.yml
@@ -5,6 +5,11 @@ on:
     branches: [main, master]
     types: [opened, synchronize, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
 jobs:
   check-guidelines:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# 📝 Description

# Fix PR Workflow Permissions for External Contributors

## Problem
PR workflows were failing with "Resource not accessible by integration" error when trying to create comments, preventing proper feedback for external contributors.

## Solution
- Added `issues: write` permission to pr-guidelines workflow
- Maintained `pull_request` trigger with explicit permissions for security
- Enables comment creation for validation feedback

## Result
- ✅ Workflows run automatically for all contributors
- ✅ No manual approval required
- ✅ Proper permissions for comment creation
- ✅ Secure execution with limited permissions

External contributors now receive immediate automated feedback without requiring maintainer approval.

# Checklist:
Tick the boxes before submitting: 

## 🔄 Type of Change
- [ ] New content
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing
- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [X] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.