### PR TITLE
fix: escape commit messages in Slack webhook payloads

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -37,7 +37,7 @@ jobs:
               "status": "${{ job.status }}",
               "repo": "${{ github.repository }}",
               "user": "${{ github.actor }}",
-              "commit_message": "${{ github.event.head_commit.message }}",
+              "commit_message": ${{ toJSON(github.event.head_commit.message) }},
               "commit_sha": "${{ github.sha }}",
               "branch": "${{ github.ref_name }}",
               "commit_url": "${{ github.event.head_commit.url }}",

--- a/.github/workflows/slack-notification.yml
+++ b/.github/workflows/slack-notification.yml
@@ -18,7 +18,7 @@ jobs:
               "status": "success",
               "repo": "${{ github.repository }}",
               "user": "${{ github.actor }}",
-              "commit_message": "${{ github.event.head_commit.message }}",
+              "commit_message": ${{ toJSON(github.event.head_commit.message) }},
               "commit_sha": "${{ github.sha }}",
               "branch": "${{ github.ref_name }}",
               "commit_url": "${{ github.event.head_commit.url }}",


### PR DESCRIPTION
# 📝 Description

Fix Slack notification JSON parsing errors

## Problem
Slack webhook notifications were failing with "Invalid input! Failed to parse contents of the provided payload" when commit messages contained newlines, quotes, or special characters.

## Solution
- Use `toJSON()` function to properly escape commit messages in both workflow files
- Prevents JSON parsing errors from multi-line commit messages
- Fixes notifications in both gh-pages-deploy and slack-notification workflows

Resolves SlackError parsing issues in GitHub Actions.

# Checklist:
Tick the boxes before submitting: 

## 🔄 Type of Change
- [ ] New content
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing
- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [X] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.