### PR TITLE
Fix IPv6 :: and AWS doc range

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -252,7 +252,8 @@ jobs:
               '2001:db8::/32', '3fff::/20',
               '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16',
               '169.254.0.0/16', '127.0.0.0/8', '224.0.0.0/4', '240.0.0.0/4', '100.64.0.0/10',
-              'fe80::/10', 'fc00::/7', '::1/128', 'ff00::/8', '::/128', '::ffff:0:0/96'
+              'fe80::/10', 'fc00::/7', '::1/128', 'ff00::/8', '::/128', '::ffff:0:0/96',
+              'fd00:ec2::/64'   # Used by AWS and appears in our documentation frequently.
           ]
           doc_networks = [ipaddress.ip_network(r) for r in doc_ranges]
           
@@ -266,7 +267,7 @@ jobs:
           def validate_ipv6(ip):
               try:
                   addr = ipaddress.IPv6Address(ip)
-                  return str(addr) == ip.lower() and '::' not in ip.replace('::', ':::')
+                  return addr.compressed == ip
               except:
                   return False
           

--- a/scripts/validate-pr.sh
+++ b/scripts/validate-pr.sh
@@ -159,7 +159,7 @@ def validate_ipv4(ip):
 def validate_ipv6(ip):
     try:
         addr = ipaddress.IPv6Address(ip)
-        return str(addr) == ip.lower() and ip.count('::') < 2
+        return addr.compressed == ip
     except:
         return False
 

--- a/scripts/validate-pr.sh
+++ b/scripts/validate-pr.sh
@@ -144,7 +144,8 @@ doc_ranges = [
     '2001:db8::/32', '3fff::/20',
     '10.0.0.0/8', '172.16.0.0/12', '192.168.0.0/16',
     '169.254.0.0/16', '127.0.0.0/8', '224.0.0.0/4', '240.0.0.0/4', '100.64.0.0/10',
-    'fe80::/10', 'fc00::/7', '::1/128', 'ff00::/8', '::/128', '::ffff:0:0/96'
+    'fe80::/10', 'fc00::/7', '::1/128', 'ff00::/8', '::/128', '::ffff:0:0/96',
+    'fd00:ec2::/64'   # Used by AWS and appears in our documentation frequently.
 ]
 doc_networks = [ipaddress.ip_network(r) for r in doc_ranges]
 
@@ -158,7 +159,7 @@ def validate_ipv4(ip):
 def validate_ipv6(ip):
     try:
         addr = ipaddress.IPv6Address(ip)
-        return str(addr) == ip.lower() and '::' not in ip.replace('::', ':::')
+        return str(addr) == ip.lower() and ip.count('::') < 2
     except:
         return False
 


### PR DESCRIPTION
# 📝 Description

Fix IPv6 validation and add AWS range fd00:ec2:: to allowed prefixes

## What Changed
validate-pr.sh

## Why This Change
The :: check had a logic issue, and fd00:ec2:: should be permitted

# Checklist:
Tick the boxes before submitting: 

## 🔄 Type of Change
- [ ] New content
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing
- [x] Ran `./scripts/validate-pr.sh` locally
- [x] Checked for broken internal links
- [x] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [x] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [x] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.