### PR TITLE
Add hostnames and SIEM to cspell dictionary

### DIFF
--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -97,7 +97,9 @@
     "vpn",
     "vxlan",
     "waf",
-    "xlarge"
+    "xlarge",
+    "hostnames",
+    "SIEM"
   ],
   "ignorePaths": [
     "node_modules/**",


### PR DESCRIPTION
# 📝 Description

Added "hostnames" and "SIEM" to cspell.json to prevent false positives during spell checking.

## 🔄 Type of Change
- [ ] New content
- [ ] Bug fix
- [ ] Documentation update
- [X] Refactoring/reorganization

## 🧪 Testing
- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [X] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.