### PR TITLE
Allow duplicate headings in different sections

### DIFF
--- a/.github/.markdownlint-cli2.yaml
+++ b/.github/.markdownlint-cli2.yaml
@@ -14,6 +14,8 @@ config:
   MD030: false  # List marker spacing - flexible
   MD004:
     style: "asterisk"  # Enforce * for unordered lists
+  MD024:
+    siblings_only: true  # Allow duplicate headings in different sections
 globs:
   - "content/**/*.md"
 ignores:


### PR DESCRIPTION
# 📝 Description

## Description
Configure MD024 rule to allow duplicate headings in different document sections.

# Checklist:
Tick the boxes before submitting: 

## 🔄 Type of Change
- [ ] New content
- [ ] Bug fix
- [ ] Documentation update
- [X] Refactoring/reorganization

## 🧪 Testing
- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [X] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.