### PR TITLE
Fix documentation issues and cleanup. Remove application networking from the hybrid network section.

### DIFF
--- a/content/hybrid-connectivity/app-networking.md
+++ b/content/hybrid-connectivity/app-networking.md
@@ -1,8 +1,0 @@
-# Coming Soon
-
-This section is under development.
-
-![Image title](../assets/hybrid-connectivity/Example.png){ width="300" }
-/// caption
-Example image caption - [Drawio Source](../assets/hybrid-connectivity/Example.drawio)
-///

--- a/content/hybrid-connectivity/index.md
+++ b/content/hybrid-connectivity/index.md
@@ -34,16 +34,6 @@ Connect your AWS infrastructure with on-premises data centers, other cloud provi
 
     [:octicons-arrow-right-24: Clients to Applications](clients-to-apps.md)
 
-*   :material-console-network: **Application Networking**
-
-    ---
-
-    Allow applications to connect to each other within AWS and beyond.
-
-    ---
-
-    [:octicons-arrow-right-24: Application Networking](app-networking.md)
-
 </div>
 
 ![Image title](../assets/hybrid-connectivity/Example.png){ width="300" }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,8 +15,8 @@ edit_uri: edit/main/content/
 # Copyright
 copyright: >
   <a href="https://aws.amazon.com/privacy/" target="_blank">Privacy</a> |
-  <a href="https://aws.amazon.com/accessibility/ target="_blank"">Accessibility</a> |
-  <a href="https://aws.amazon.com/terms/ target="_blank"">Site Terms</a> |
+  <a href="https://aws.amazon.com/accessibility/" target="_blank">Accessibility</a> |
+  <a href="https://aws.amazon.com/terms/" target="_blank">Site Terms</a> |
   <a href="#__consent">Cookie Preferences </a> |
   &copy; 2025, Amazon Web Services, Inc. or its affiliates. All rights reserved.
 
@@ -110,19 +110,14 @@ markdown_extensions:
   - pymdownx.snippets:
       auto_append:
         - includes/abbreviations.md
-  - pymdownx.superfences
   - pymdownx.details
   - pymdownx.tabbed:
       alternate_style: true
-  - admonition
-  - pymdownx.details
-  - pymdownx.superfences
   - pymdownx.caret
   - pymdownx.mark
   - pymdownx.tilde
   - attr_list
   - md_in_html
-  - pymdownx.superfences
   - tables
   - pymdownx.emoji:
       emoji_index: !!python/name:material.extensions.emoji.twemoji
@@ -184,7 +179,6 @@ nav:
       - Network to Network: hybrid-connectivity/network-to-network.md
       - Clients to Network: hybrid-connectivity/clients-to-network.md
       - Clients to Applications: hybrid-connectivity/clients-to-apps.md
-      - Application Networking: hybrid-connectivity/app-networking.md
   - Network Security:
       - security/index.md
       - Perimeter Controls: security/perimeter-inbound.md


### PR DESCRIPTION
# 📝 Description

- Remove app-networking.md and references
- Fix duplicate markdown extensions in mkdocs.yml
- Fix HTML syntax in copyright links

Fixes #61

## 🔄 Type of Change
- [ ] New content
- [X] Bug fix
- [X] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing
- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [X] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.