### PR TITLE
Fix duplicate Slack notifications

### DIFF
--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -4,9 +4,6 @@ on:
   pull_request_target:
     types: [opened]
     branches: [main, master]
-  pull_request:
-    types: [opened]
-    branches: [main, master]
 
 jobs:
   notify-slack:


### PR DESCRIPTION
# 📝 Description

Remove duplicate GitHub event trigger to prevent double Slack notifications for new PRs.

# Checklist:
Tick the boxes before submitting: 

## 🔄 Type of Change
- [ ] New content
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing
- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [X] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.