### PR TITLE
fix: remove duplicate pull_request triggers from workflows

### DIFF
--- a/.github/workflows/markdown-preview.yml
+++ b/.github/workflows/markdown-preview.yml
@@ -1,10 +1,6 @@
 name: Markdown Preview
 
 on:
-  pull_request:
-    branches: [main, master]
-    paths:
-      - 'content/**/*.md'
   pull_request_target:
     branches: [main, master]
     paths:

--- a/.github/workflows/pr-guidelines.yml
+++ b/.github/workflows/pr-guidelines.yml
@@ -1,9 +1,6 @@
 name: PR Guidelines Check
 
 on:
-  pull_request:
-    branches: [main, master]
-    types: [opened, synchronize, reopened]
   pull_request_target:
     branches: [main, master]
     types: [opened, synchronize, reopened]

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,9 +1,6 @@
 name: PR Validation
 
 on:
-  pull_request:
-    branches: [main, master]
-    types: [opened, synchronize, reopened]
   pull_request_target:
     branches: [main, master]
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
# 📝 Description

## Fix workflow permission errors

- Removes duplicate `pull_request` triggers from GitHub workflows
- Keeps only `pull_request_target` triggers to fix permission issues
- Resolves "Resource not accessible by integration" errors

# Checklist:
Tick the boxes before submitting: 

## 🔄 Type of Change
- [ ] New content
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing
- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [X] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.