### PR TITLE
ci: restrict gh-pages-deploy to main repo only

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -4,6 +4,9 @@ on:
     branches:
       - master 
       - main
+
+# Only run in the main repository, not in forks
+if: github.repository == 'aws/aws-networking-best-practices'
 permissions:
   contents: write
 jobs:


### PR DESCRIPTION
# 📝 Description

## Prevent workflow execution in forks

Adds repository check to ensure gh-pages-deploy workflow only runs in the main aws/aws-networking-best-practices repository.

# Checklist:
Tick the boxes before submitting: 

## 🔄 Type of Change
- [ ] New content
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing
- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [X] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.