### PR TITLE
Ignore text within backticks in spell checker

### DIFF
--- a/.github/cspell.json
+++ b/.github/cspell.json
@@ -1,6 +1,9 @@
 {
   "version": "0.2",
   "language": "en",
+  "ignoreRegExpList": [
+    "`[^`]*`"  // Ignore text within backticks
+  ],
   "words": [
     "acl",
     "acls",


### PR DESCRIPTION
# 📝 Description

## Description
This PR adds a regular expression pattern to the cspell configuration that ignores any text enclosed in backticks (`example`). This improves the developer experience by allowing inline code, commands, and technical terms to be written without triggering spell check errors.

## Changes
- Added `ignoreRegExpList` configuration to `.github/cspell.json`
- Implemented regex pattern to ignore text between backtick characters

## Testing
Verified that text within backticks is now ignored by the spell checker.

# Checklist:
Tick the boxes before submitting: 

## 🔄 Type of Change
- [ ] New content
- [ ] Bug fix
- [ ] Documentation update
- [X] Refactoring/reorganization

## 🧪 Testing
- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [X] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.