### PR TITLE
Fix tooltip display for monitoring symbols

### DIFF
--- a/content/monitoring-observability/service-monitoring.md
+++ b/content/monitoring-observability/service-monitoring.md
@@ -7,17 +7,17 @@ For the metrics, the following symbols are used:
 
 | Symbol | Meaning |
 | :-: | --- |
-| :material-alarm-light:{ title=Alarm any time the condition exists. } | Alarm any time the condition exists. |
-| :material-exclamation-thick:{ title=These statistics should trigger alarms if the condition persists for several minutes. A couple increments occasionally should be expected as a normal part of networking. } | These statistics should trigger alarms if the condition persists for several minutes. A couple increments occasionally should be expected as a normal part of networking. |
-| :material-eye-check:{ title=These statistics should always be monitored, and may be alarmed depending on specific use case. } | These statistics should always be monitored, and may be alarmed depending on specific use case. |
+| :material-alarm-light:{ title="Alarm any time the condition exists". } | Alarm any time the condition exists. |
+| :material-exclamation-thick:{ title="These statistics should trigger alarms if the condition persists for several minutes. A couple increments occasionally should be expected as a normal part of networking." } | These statistics should trigger alarms if the condition persists for several minutes. A couple increments occasionally should be expected as a normal part of networking. |
+| :material-eye-check:{ title="These statistics should always be monitored, and may be alarmed depending on specific use case." } | These statistics should always be monitored, and may be alarmed depending on specific use case. |
 
 For quotas:
 
 | Symbol | Meaning |
 | :-: | --- |
-| :octicons-stop-16:{ title=Hard quota – Cannot be adjusted. } | Hard quota – Cannot be adjusted. |
-| :fontawesome-solid-road-barrier:{ title=Medium quota - Contact AWS to discuss these and possible alternative architectures. } | Medium quota - Contact AWS to discuss these and possible alternative architectures. |
-| :material-image-auto-adjust:{ title=Soft quota - Adjustable by customer. } | Soft quota - Adjustable by customer. |
+| :octicons-stop-16:{ title="Hard quota – Cannot be adjusted." } | Hard quota – Cannot be adjusted. |
+| :fontawesome-solid-road-barrier:{ title="Medium quota - Contact AWS to discuss these and possible alternative architectures." } | Medium quota - Contact AWS to discuss these and possible alternative architectures. |
+| :material-image-auto-adjust:{ title="Soft quota - Adjustable by customer." } | Soft quota - Adjustable by customer. |
 
 !!! info "Remember"
     Always validate the quotas below against the official AWS documentation - in case of differences, the official quotas should be used. Not all quotas are repeated here - only the most critical ones to keep an eye on.


### PR DESCRIPTION
# 📝 Description

## Description
This PR fixes an issue with the tooltip display when hovering over the monitoring symbols in the service monitoring documentation. The tooltips were not displaying correctly, making it difficult for users to understand the meaning of the symbols without referring to the legend.

## Changes
- Updated the title attributes for all monitoring symbols in service-monitoring.md
- Ensured consistent formatting across all tooltip text
- Maintained the same explanatory content while fixing the display issue

## Testing
Verified that tooltips now appear correctly when hovering over the monitoring symbols in the rendered documentation.

# Checklist:
Tick the boxes before submitting: 

## 🔄 Type of Change
- [ ] New content
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing
- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [X] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.