### PR TITLE
Update index.md

### DIFF
--- a/content/basics/index.md
+++ b/content/basics/index.md
@@ -301,7 +301,7 @@ Unclear security boundaries lead to gaps in coverage, conflicts between rules, a
 
 For example, use NACLs to block entire countries or IP ranges for compliance, deny traffic between development and production subnets, or implement broad protocol restrictions. Use Security Groups for application-specific rules like allowing web servers to access specific database ports or enabling communication between microservices.
 
-Document your security model clearly and train your team on when to use each layer. Create standard templates for common scenarios. Also, consider using AWS Config rules to monitor for configuration drift and ensure your security policies remain consistent over time. Beware of AWS Config [cost](https://aws.amazon.com/config/pricing/). 
+Document your security model clearly and train your team on when to use each layer. Create standard templates for common scenarios. Also, consider using AWS Config rules to monitor for configuration drift and ensure your security policies remain consistent over time. Beware of AWS Config [cost](https://aws.amazon.com/config/pricing/).
 
 ### Plan for Multi-Account and Cross-VPC Communication Patterns
 

--- a/content/basics/index.md
+++ b/content/basics/index.md
@@ -234,9 +234,128 @@ Monitor your query patterns and optimize application-level DNS caching to reduce
 * [How do I determine whether my DNS queries to the Amazon DNS server fail because of VPC DNS throttling?](https://repost.aws/knowledge-center/vpc-find-cause-of-failed-dns-queries)
 * [How does DNS work, and how do I troubleshoot partial or intermittent DNS failures?](https://repost.aws/knowledge-center/partial-dns-failures)
 
-## 13. Security Groups vs. Network ACLs
+## 13. Security Groups vs. Network Access Control Lists (NACLs)
 
-Difference between these and when to use each approach.
+The choice between the two security layers, VPC [Security Groups](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-groups.html) and [Network Access Control Lists (NACLs)](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-network-acls.html), often determines whether you'll have a maintainable, scalable network architecture or a complex set of rules that becomes increasingly difficult to manage as your infrastructure grows. The most common misconception is treating Security Groups and NACLs as interchangeable tools. Customers often default to what they know from traditional networking—implementing subnet-level controls with NACLs because "that's how we've always done firewalls." This approach frequently leads to over-engineered solutions that are difficult to troubleshoot and maintain. Conversely, some customers rely solely on Security Groups without understanding when network-level controls provide superior security or operational benefits.
+
+### Start with Security Groups, use NACLs for Specific Use Cases
+
+Most customers jump straight to implementing both Security Groups and NACLs simultaneously, creating unnecessary complexity from day one. In an Amazon VPC, Network ACLs are optional for subnet-level traffic filtering, while Security Groups are mandatory for instance-level protection.
+
+Security Groups provide 90% of what most applications need for network security. Adding NACLs without a clear use case creates operational overhead, increases troubleshooting complexity, and often introduces subtle connectivity issues that are difficult to diagnose. Customers may spend considerable time debugging connectivity problems that stem from conflicting NACL rules they forgot they implemented.
+
+Begin every VPC design with Security Groups as your primary security control. Only implement NACLs when you have specific requirements such as:
+
+* Compliance mandates requiring  subnet-level controls
+* Defense-in-depth requirements for  highly sensitive workloads
+* Network-level logging for  forensics or compliance
+* Blocking traffic between subnets  in the same VPC
+* Implementing coarse-grained deny  rules for entire subnet ranges
+
+Document your NACL implementation rationale clearly. Create a decision matrix that explains why NACLs are necessary for each subnet. This prevents future team members from removing "seemingly redundant" rules that serve critical security functions. Also, remember that NACLs evaluate rules in order—always place your most specific deny rules at the top, followed by broader allow rules.
+
+### Use Security Group Referencing for Dynamic Architectures
+
+Customers often hard-code IP addresses or CIDR blocks in Security Group rules, creating configurations that break when infrastructure scales or changes.
+
+[Security Group referencing](https://repost.aws/articles/ARY9viGjzLTSS_4UYNudZl9Q/how-to-check-security-group-references-within-and-across-vpcs) allows you to create dynamic, self-maintaining security policies that automatically adapt as your infrastructure scales. Without this approach, you'll spend significant operational time updating security rules every time you add new instances, change IP ranges, or implement auto-scaling.
+
+Design Security Groups to reference other Security Groups rather than IP addresses wherever possible. Create logical groupings like "web-tier-sg," "app-tier-sg," and "database-tier-sg," then allow traffic between these groups by referencing the source Security Group ID. This creates a logical security model that remains valid regardless of the actual IP addresses assigned to instances.
+
+For multi-VPC architectures, you can reference Security Groups across VPCs that are connected via VPC peering, AWS Transit Gateway, or VPC sharing. This enables consistent security policies across your entire AWS infrastructure without maintaining separate rule sets.
+
+Use descriptive Security Group names and descriptions that clearly indicate their purpose. Customers often use generic names like "sg-12345" that become challenging to manage at scale. Also, consider creating "service" Security Groups that define what ports and protocols a service needs, separate from "client" Security Groups that define what can access those services.
+
+### Understand the Stateful vs. Stateless Implications for Application Architecture
+
+Customer often don't understand how the stateful nature of Security Groups vs the stateless nature of NACLs affects their application design, leading to connectivity issues that are difficult to troubleshoot.
+
+The stateful nature of Security Groups means return traffic is automatically allowed, while NACLs require explicit rules for both inbound and outbound traffic. This fundamental difference affects how you design applications, especially those that use [ephemeral ports](https://en.wikipedia.org/wiki/Ephemeral_port), establish database connections, or implement health checks.
+
+For Security Groups, you typically only need to define inbound rules for services—the outbound return traffic is automatically allowed. However, you should still implement explicit outbound rules following the principle of least privilege. For example, allow your web servers to reach only specific database ports rather than leaving outbound rules completely open.
+
+With NACLs, you must account for both directions of traffic flow. This includes ephemeral port ranges (typically `32768-65535` for Linux, `49152-65535` for Windows Server 2008+) for return traffic. Consider the operational complexity this creates—every new service or application may require updates to both inbound and outbound NACL rules.
+
+When using NACLs with load balancers, remember that health checks originate from the load balancer's IP range and require explicit rules. For Application Load Balancers (ALB), the source IP will be the ALB's private IP addresses. For Network Load Balancers (NLB), the source IP could be the client's IP (in IP target mode) or the NLB's IP (in instance target mode).
+
+### Design for IPv6 and Dual-Stack from the Beginning
+
+Many customers implement IPv4-only security rules initially, then struggle to retrofit IPv6 support when business requirements or compliance mandates drive adoption.
+
+IPv6 adoption is accelerating due to IoT growth, mobile applications, and compliance requirements. Retrofitting IPv6 support into existing Security Group and NACL configurations is error-prone and often requires significant architectural changes. Customer may spend months reworking their security policies when they could have designed for dual-stack from the beginning.
+
+When creating Security Groups and NACLs, consider whether you need IPv6 support now or in the future. If there's any possibility of IPv6 adoption, implement dual-stack rules from the beginning. This means creating parallel rule sets for both IPv4 and IPv6 address families.
+
+For Security Groups, create separate rules for IPv4 (using CIDR blocks such as `10.0.0.0/8`) and IPv6 (using CIDR blocks such as `2001:db8::/32`). For NACLs, you'll need separate rule numbers for IPv4 and IPv6 traffic, as they're evaluated independently.
+
+IPv6 security considerations differ from IPv4. IPv6 addresses are globally routable by default, though you still need an [IGW](https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Internet_Gateway.html) or [EIGW](https://docs.aws.amazon.com/vpc/latest/userguide/egress-only-internet-gateway.html) in your VPC, so your security policies must account for this. Also, IPv6 doesn't use NAT in the traditional sense, which changes how you think about outbound internet access. Consider using egress-only internet gateways for IPv6 outbound traffic that shouldn't accept inbound connections from the internet.
+
+### Implement Layered Security with Clear Boundaries and Responsibilities
+
+Customers often implement overlapping security controls without clear boundaries, creating confusion about which layer handles which security concerns.
+
+Unclear security boundaries lead to gaps in coverage, conflicts between rules, and operational confusion during incident response. When security layers overlap without clear ownership, critical updates might be missed, or conflicting changes might be made simultaneously. Define clear responsibilities for each security layer. A common pattern is:
+
+* NACLs: Coarse-grained network controls, compliance requirements, and subnet-level isolation
+* Security Groups: Fine-grained application controls, service-to-service communication, and dynamic scaling scenarios
+
+For example, use NACLs to block entire countries or IP ranges for compliance, deny traffic between development and production subnets, or implement broad protocol restrictions. Use Security Groups for application-specific rules like allowing web servers to access specific database ports or enabling communication between microservices.
+
+Document your security model clearly and train your team on when to use each layer. Create standard templates for common scenarios. Also, consider using AWS Config rules to monitor for configuration drift and ensure your security policies remain consistent over time. Beware of AWS Config [cost](https://aws.amazon.com/config/pricing/). 
+
+### Plan for Multi-Account and Cross-VPC Communication Patterns
+
+Many customers start with single-VPC designs but eventually need to support multi-VPC or multi-account architectures, often requiring significant security policy rework.
+
+Cross-VPC communication through AWS Transit Gateway, VPC peering, or inter-region connectivity requires careful planning of Security Group and NACL strategies. Poorly planned cross-VPC security can create bottlenecks, security gaps, or overly permissive rules that violate compliance requirements.
+
+When designing security policies, consider your future multi-VPC needs. Security Groups can reference other Security Groups across VPC peers and AWS Transit Gateway attachments, enabling consistent security policies across your infrastructure. NACLs, however, work only at the subnet level within individual VPCs.
+
+For [AWS Transit Gateway](https://aws.amazon.com/transit-gateway/) environments, consider creating centralized Security Groups that can be referenced across multiple VPCs. This enables consistent security policies while maintaining the flexibility to customize rules for specific environments or applications.
+
+Use [AWS Resource Access Manager (RAM)](https://aws.amazon.com/ram/) to share AWS Transit Gateways and other networking resources across accounts while maintaining security boundaries. Also, consider using VPC endpoints for AWS services to avoid routing traffic through your security layers unnecessarily, which can simplify your rule sets and improve performance.
+
+### Optimize for Scale and Performance Characteristics
+
+Customers often don't consider the scale and performance implications of their Security Group and NACL designs until they encounter limits or performance issues in production.
+
+Security Groups and NACLs have different scale characteristics and performance implications. Understand the [service quotas](https://docs.aws.amazon.com/vpc/latest/userguide/amazon-vpc-limits.html) for both Security Groups and NACLs. Each Security Group can have up to `60` inbound and `60` outbound rules, and each network interface can be associated with up to `5` Security Groups (giving you effectively `300` inbound and `300` outbound rules per interface). NACLs can have up to `20` rules each for inbound and outbound traffic per NACL.
+
+Plan your rule consolidation strategy early. Instead of creating many specific rules, use CIDR aggregation where possible. For example, instead of creating separate rules for `10.0.1.0/24`, `10.0.2.0/24`, and `10.0.3.0/24`, use a single rule for `10.0.0.0/22` if the security requirements are identical.
+
+Monitor your Security Group and NACL rule counts using [AWS Config](https://docs.aws.amazon.com/config/latest/developerguide/WhatIsConfig.html). Beware of the AWS Config [cost](https://aws.amazon.com/config/pricing/).
+
+### Key Considerations
+
+**Treating NACLs Like Traditional Firewalls**: Customers may implement complex NACL rule sets trying to replicate their on-premises firewall configurations. They create dozens of specific rules for individual applications, protocols, and port ranges, often resulting in NACLs with many rules that are difficult to understand and maintain.
+
+Look for NACLs with many specific rules, especially those that seem to duplicate functionality available in Security Groups. Another sign is when teams modify NACLs frequently as part of application deployments—this suggests they're using NACLs for dynamic, application-level controls that would be better handled by Security Groups.
+
+Audit your existing NACL rules and categorize them into network-level controls (keep in NACLs) vs application-level controls (migrate to Security Groups). Start by removing NACL rules that duplicate Security Group functionality. For complex rule sets, create a migration plan that moves rules to Security Groups in phases, testing connectivity after each phase. Use VPC Flow Logs during the migration to verify that legitimate traffic isn't being blocked.
+
+**Creating Overly Permissive Security Groups to Avoid NACL Complexity**: Customers implementing both Security Groups and NACLs sometimes create overly broad Security Group rules (like allowing all traffic on all ports) because they assume the NACLs will provide the necessary restrictions. This creates a false sense of security while actually reducing your overall security posture.
+
+Look for Security Groups with rules like `0.0.0.0/0` on all ports, or Security Groups that allow broad port ranges without clear justification. Another indicator is when Security Group rules haven't been updated in months while NACL rules are frequently modified—this suggests the Security Groups aren't being used as intended.
+
+Implement proper Security Group rules first, then evaluate whether your NACLs are actually necessary. Use AWS Config rules to identify overly permissive Security Groups and create remediation plans. The key is to make each layer do what it does best rather than relying on one to compensate for weaknesses in the other.
+
+**Ignoring Ephemeral Port Requirements in NACL Design**: Customers implement restrictive outbound NACL rules without accounting for ephemeral ports used by return traffic, causing intermittent connectivity issues that are difficult to troubleshoot. Applications work sometimes but fail others, especially during high-traffic periods when different ephemeral ports are used.
+
+Look for applications that experience intermittent connectivity issues, especially for outbound connections to databases, APIs, or external services. VPC Flow Logs showing `REJECT` entries for high port numbers (typically above `32768`) often indicate this problem. Another sign is when applications work from some subnets but not others, despite having identical Security Group rules.
+
+Review all outbound NACL rules and ensure they account for return traffic on ephemeral ports. This typically means allowing outbound traffic on ports `32768-65535` for Linux instances or `49152-65535` for Windows instances. If security requirements prevent opening these ranges broadly, consider redesigning your application architecture to use specific port ranges that you can control, or evaluate whether the NACL restrictions are truly necessary for your security model.
+
+### Operational Considerations
+
+Managing Security Groups and NACLs effectively requires ongoing attention to monitoring, troubleshooting, and optimization. [VPC Flow Logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html) is the primary tool for understanding traffic patterns and diagnosing connectivity issues. Enable Flow Logs at the VPC level and configure them to capture both accepted and rejected traffic. Use [Amazon CloudWatch Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/AnalyzingLogData.html) or [Amazon Athena](https://aws.amazon.com/athena/) to query Flow Logs efficiently—Create saved queries for common troubleshooting scenarios like identifying blocked traffic or analyzing traffic patterns between security groups. Beware of [Amazon CloudWatch](https://aws.amazon.com/cloudwatch/pricing/) and [Amazon Athena](https://aws.amazon.com/athena/pricing/) costs.
+
+For cost optimization, remember that VPC Flow Logs incur storage and analysis costs that can become significant at scale. Consider using sampling or filtering to reduce costs while maintaining visibility into your traffic patterns. AWS Config provides continuous monitoring of Security Group and NACL configurations, helping you identify configuration drift and ensure compliance with your security standards. Set up Config rules to alert on overly permissive rules, unused Security Groups, or changes to critical NACL configurations.
+
+Integration with other AWS services requires careful consideration of how Security Groups and NACLs affect service functionality. AWS services like Application Load Balancers, RDS, and Lambda have specific networking requirements that must be accounted for in your security policies. For example, RDS instances in private subnets require appropriate Security Group rules for database access, while Lambda functions need outbound internet access for API calls unless you're using VPC endpoints. Understanding these service-specific requirements helps you design security policies that enhance rather than hinder your application architecture. AWS provides extensive documentation on networking requirements for each service, and the [AWS Well-Architected Framework - Security Pillar](https://docs.aws.amazon.com/wellarchitected/latest/security-pillar/protecting-networks.html) includes guidance on implementing defense-in-depth networking strategies that leverage both Security Groups and NACLs effectively.
+
+### Relevant Resources
+
+* [VPC Security best practices](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-security-best-practices.html)
 
 ## 14. Network Performance and Sizing
 


### PR DESCRIPTION
Added sub-section number 13 "Security Groups vs. Network Access Control (ACLs):  Difference between these and when to use each approach" under the Networking basics.

# 📝 Description

<!-- 
Added sub-section # 13 "Security Groups vs. Network Access Control (ACLs):  Difference between these and when to use each approach" under the Networking basics.

## What Changed
Added sub-section # 13 "Security Groups vs. Network Access Control (ACLs):  Difference between these and when to use each approach" under the Networking basics.

## Why This Change
Added sub-section # 13 "Security Groups vs. Network Access Control (ACLs):  Difference between these and when to use each approach" under the Networking basics.

**Related issue/discussion:**
Fixes #(issue) or Relates to #(discussion)

<!--
Need help writing a good description? Here are some examples:

✅ Good: "Add Transit Gateway best practices section to address common multi-account connectivity patterns. Includes routing recommendations and security considerations based on customer feedback in issue #123."

✅ Good: "Reorganize networking fundamentals section for better learning flow, moving basic concepts before advanced topics as suggested in discussion #456."

❌ Avoid: "Update docs", "Various fixes", "Add content"
-->

# Checklist:
Tick the boxes before submitting: 

## 🔄 Type of Change
- [X] New content
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing
- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [X] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.