### PR TITLE
added user agent for connecting to w3.org

### DIFF
--- a/.github/mlc_config.json
+++ b/.github/mlc_config.json
@@ -1,16 +1,24 @@
 {
+  "httpHeaders": [
+    {
+      "urls": ["w3.org"],
+      "headers": {
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36"
+      }
+    }
+  ],
   "ignorePatterns": [
     {
       "pattern": "^http://localhost"
     },
     {
-      "pattern": "^http://127.0.0.1"
+      "pattern": "^127.0.0.1" Note: Please be mindful when interacting with displayed links.
     },
     {
-      "pattern": "^https://example.com"
+      "pattern": "^example.com" Note: Please be mindful when interacting with displayed links.
     },
     {
-      "pattern": "^https://github.com/aws/aws-networking-best-practices"
+      "pattern": "^github.com/aws/aws-networking-best-practices" Note: Please be mindful when interacting with displayed links.
     }
   ],
   "timeout": "20s",


### PR DESCRIPTION
fixing link checker failures

# 📝 Description

<!-- 
🚨 IMPORTANT: Replace this entire section with your own description
Delete everything from here down to the "Checklist" section and write your own summary
-->

[Replace this with a clear summary of what you changed and why]

## What Changed
Updated the mlc_config.json file with new configuration. 

## Why This Change
linkchecker is failing on a PR for a w3.org page likely due to blocked github user agent. Created config to spoof a user agent and have the link checker succeed. 

-->

# Checklist:
Tick the boxes before submitting: 

## 🔄 Type of Change
- [ ] New content
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing
- [ ] Ran `./scripts/validate-pr.sh` locally
- [ ] Checked for broken internal links
- [ ] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [ ] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [ ] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.