### PR TITLE
Fix markdown preview workflow permissions error

### DIFF
--- a/.github/workflows/markdown-preview.yml
+++ b/.github/workflows/markdown-preview.yml
@@ -24,7 +24,8 @@ jobs:
           script: |
             const { execSync } = require('child_process');
             
-            const changedFiles = execSync(`git diff --name-only origin/${{ github.base_ref }}...HEAD`)
+            const baseBranch = context.payload.pull_request.base.ref;
+            const changedFiles = execSync(`git diff --name-only origin/${baseBranch}...HEAD`)
               .toString().trim().split('\n').filter(f => f.endsWith('.md'));
             
             // Skip preview if multiple markdown files detected (handled by pr-guidelines workflow)
@@ -34,7 +35,7 @@ jobs:
             }
             
             for (const file of changedFiles) {
-              const diffOutput = execSync(`git diff origin/${{ github.base_ref }}...HEAD -- "${file}"`)
+              const diffOutput = execSync(`git diff origin/${baseBranch}...HEAD -- "${file}"`)
                 .toString();
               
               function processMarkdown(lines) {


### PR DESCRIPTION
## Fix markdown preview workflow permissions error

### Problem
The markdown preview workflow was failing with a 403 "Resource not accessible by integration" error when trying to create PR comments.

### Solution
- Replace `${{ github.base_ref }}` with `context.payload.pull_request.base.ref` to use the proper pull request context
- This ensures the workflow can access the correct base branch reference within the GitHub Actions environment

# Checklist:
Tick the boxes before submitting: 

## 🔄 Type of Change
- [ ] New content
- [X] Bug fix
- [ ] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing
- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [X] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.