### PR TITLE
Add venv to .gitignore and update pull request docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 site
 .cache
 .DS_Store
+venv

--- a/content/community/making-a-pull-request.md
+++ b/content/community/making-a-pull-request.md
@@ -113,15 +113,15 @@ Thank you for helping improve AWS networking guidance for the community.
 
 First, clone the repository.
 
-    ```
-    git clone https://github.com/YOUR-USERNAME/aws-networking-best-practices
-    cd aws-networking-best-practices
-    ```
+```
+git clone https://github.com/YOUR-USERNAME/aws-networking-best-practices
+cd aws-networking-best-practices
+```
 Next, create a new [Python virtual environment][venv] and
 [activate][venv-activate] it:
 
 ```
-python -m venv venv
+python3 -m venv venv
 source venv/bin/activate
 ```
 
@@ -135,24 +135,24 @@ source venv/bin/activate
     you may want to add this to your `.bashrc` or `.zshrc` and
     re-start your shell:
 
-    ```
-    export PIP_REQUIRE_VIRTUALENV=true
-    ```
+```
+export PIP_REQUIRE_VIRTUALENV=true
+```
 
   [venv]: https://docs.python.org/3/library/venv.html
   [venv-activate]: https://docs.python.org/3/library/venv.html#how-venvs-work
 
 Then, install all Python dependencies:
 
-    ```
-    pip install \
-                mkdocs-material \
-                mkdocs-git-revision-date-localized-plugin \
-                mkdocs-git-committers-plugin-2 \
-                "mkdocs-material[imaging]" \
-                yamllint \
-                mdx-spanner
-    ```
+```
+pip install \
+        mkdocs-material \
+        mkdocs-git-revision-date-localized-plugin \
+        mkdocs-git-committers-plugin-2 \
+        "mkdocs-material[imaging]" \
+        yamllint \
+        mdx-spanner
+```
 
 ### Live Preview
 


### PR DESCRIPTION
# 📝 Description

Minor housekeeping: add `venv` to `.gitignore` and fix formatting/accuracy in the pull request contribution guide.

## What Changed

- `.gitignore` — added `venv` so Python virtual environments aren't accidentally committed.
- `content/community/making-a-pull-request.md` — fixed indented code blocks to use standard fenced code blocks, and changed `python` to `python3` for broader compatibility.

## Why This Change

The `venv` directory was missing from `.gitignore`, which could lead to contributors accidentally committing their virtual environment. The docs formatting fixes ensure code blocks render correctly in MkDocs and that the setup instructions work on systems where `python` isn't aliased to Python 3.

**Related issue/discussion:**
N/A — general contributor experience improvement.

# Checklist:

Tick the boxes before submitting:

## 🔄 Type of Change

- [ ] New content
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing

- [ ] Ran `./scripts/validate-pr.sh` locally
- [ ] Checked for broken internal links
- [ ] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards

- [x] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [x] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
