### PR TITLE
Add Observability section content

### DIFF
--- a/content/observability/external-traffic.md
+++ b/content/observability/external-traffic.md
@@ -1,3 +1,401 @@
 # External Traffic Monitoring
 
-Content coming soon.
+!!! info "Prerequisites"
+    This section assumes familiarity with [Internet Connectivity](../connectivity/internet.md), [Load Balancing](../application-networking/load-balancing.md), and [Outbound Controls](../security/outbound.md). Review those topics first if you're new to AWS networking fundamentals.
+
+External traffic monitoring covers visibility into every flow that crosses the boundary between your AWS environment and the public internet — both ingress from clients reaching your applications and egress from your workloads reaching external services. This is the observability layer that answers questions no internal monitoring can: how are real clients experiencing your application, what is the actual latency at the edge, which external destinations are your workloads calling, and where is your egress spend going?
+
+The challenge is not a lack of data sources — AWS provides logging at every layer from the CDN edge to the NAT Gateway. The challenge is knowing which data source answers which question, when real-time analysis justifies its cost over batch processing, and how to correlate signals across layers to build a complete picture of a single external flow. This page is organized by observability layer, from the edge inward, and covers the architectural decisions that determine which combination of logs and metrics you need.
+
+The organizing principle is **layered external observability**: each layer captures what the layers above and below cannot see, and the combination gives you full-path visibility without redundant collection.
+
+``` mermaid
+graph TB
+    subgraph External["External Traffic Observability Layers"]
+        direction TB
+        Edge["CloudFront access logs / real-time logs<br/>+ Route 53 query logs<br/>(edge-level: client IP, latency, cache, DNS patterns)"]
+        WAF["AWS WAF logs<br/>(security evaluation: rule matches, allow/block/count)"]
+        LB["ALB access logs / NLB access logs<br/>(per-request/connection: target latency, response codes, TLS details)"]
+        VPC["NAT Gateway CloudWatch metrics<br/>+ VPC Flow Logs<br/>(egress volume, connection counts, packet drops)"]
+    end
+
+    Client["Internet clients"] --> Edge
+    Edge --> WAF
+    WAF --> LB
+    LB --> VPC
+    VPC --> Destination["External destinations"]
+
+    style External fill:none,stroke:#2563eb,stroke-width:2px,stroke-dasharray:5 5,color:#2563eb
+    style Edge fill:#2563eb,stroke:#1e40af,color:#fff
+    style WAF fill:#7c3aed,stroke:#6d28d9,color:#fff
+    style LB fill:#2563eb,stroke:#1e40af,color:#fff
+    style VPC fill:#059669,stroke:#047857,color:#fff
+    style Client fill:#ff9900,stroke:#cc7a00,color:#fff
+    style Destination fill:#ff9900,stroke:#cc7a00,color:#fff
+```
+
+Each layer captures distinct information: CloudFront logs show what the client experienced at the edge (cache hit or miss, edge latency, protocol version). WAF logs show which requests were evaluated and what security decisions were made. ALB/NLB logs show what happened between the load balancer and your targets (target response time, backend errors). NAT Gateway metrics and VPC Flow Logs show what your workloads sent outbound and how much it cost. No single layer gives you the full picture — the combination does.
+
+## Key capabilities
+
+<div class="grid cards" markdown>
+
+*   :material-cloud-download: **CloudFront access logs and real-time logs**
+
+    ---
+
+    Edge-level visibility into every client request: latency, cache status (hit/miss/error), client IP (IPv4 and IPv6), HTTP protocol version, TLS version, and geographic distribution. Real-time logs deliver to Kinesis Data Streams within seconds for live dashboards.
+
+*   :material-scale-balance: **ALB and NLB access logs**
+
+    ---
+
+    Per-request (ALB) or per-connection (NLB) logs with client IP, request details, response code, target processing time, and TLS handshake metadata. The primary ingress observability tool for understanding what happens between the load balancer and your targets.
+
+*   :material-shield-alert: **AWS WAF logs**
+
+    ---
+
+    Per-request evaluation results showing which rules matched, the action taken (allow, block, count, CAPTCHA), and the request attributes that triggered the match. Essential for security investigation and tuning WAF rules without blind spots.
+
+*   :material-upload-network: **NAT Gateway CloudWatch metrics**
+
+    ---
+
+    Bytes processed, packets dropped, active connections, connection attempts, and error counts. The primary tool for egress cost visibility and detecting workloads that are generating unexpected outbound traffic.
+
+*   :material-earth: **AWS Global Accelerator flow logs**
+
+    ---
+
+    Client-to-accelerator traffic visibility for L4 workloads using anycast entry points. Captures source/destination IPs, ports, protocol, bytes, and packets for every flow through the accelerator.
+
+*   :material-dns: **Route 53 query logs**
+
+    ---
+
+    DNS query patterns for your public hosted zones: which domains are queried, from which resolver IPs, and at what volume. Useful for detecting reconnaissance, measuring DNS-level traffic distribution, and validating failover behavior.
+
+</div>
+
+## Best Practices
+
+### Ingress observability
+
+#### Always enable ALB access logs — they are your primary ingress data source
+
+ALB access logs capture every request that reaches the load balancer: client IP (IPv4 or IPv6), request URL, response code, request processing time, target processing time, and the target that served the request. There is no additional charge from ALB for access logs — you pay only for S3 storage. The cost is negligible relative to the operational value.
+
+ALB access logs answer the questions that CloudWatch metrics cannot: which specific clients are seeing errors, which targets are slow, what the latency distribution looks like at the request level (not just averages), and whether a 5xx spike is coming from one target or all of them. Without access logs enabled, you're debugging production incidents with aggregated metrics alone.
+
+Enable access logs on every ALB at creation time. Deliver them to a centralized logging account's S3 bucket using cross-account delivery (ALB writes directly to the bucket; configure the bucket policy to allow the ELB service principal for your Region). Partition logs by account, Region, and date for efficient querying with Amazon Athena.
+
+***Key insight:*** *ALB access logs are free to generate, cost pennies to store, and are irreplaceable during incident investigation. There is no valid reason to leave them disabled on a production ALB.*
+
+#### Enable NLB access logs for TLS and connection-level visibility
+
+NLB access logs capture connection-level details that ALB logs do not: TLS handshake latency, TLS cipher negotiated, client certificate details (for mutual TLS), connection duration, and bytes transferred per connection. For L4 workloads where you need to understand connection patterns rather than individual requests, NLB logs are the primary data source.
+
+NLB access logs are disabled by default and must be explicitly enabled. Like ALB logs, they deliver to S3 with no additional NLB charge. Enable them on every internet-facing NLB, particularly those terminating TLS, to maintain visibility into client connection behavior and TLS negotiation failures.
+
+#### Use CloudFront real-time logs for live operational visibility
+
+CloudFront offers two logging modes: standard logs (delivered to S3 in batches, typically within minutes) and real-time logs (delivered to Kinesis Data Streams within seconds). Standard logs are sufficient for post-incident analysis and trend reporting. Real-time logs are justified when you need live dashboards, sub-minute alerting on error rates, or immediate visibility into cache behavior changes during deployments.
+
+The cost difference is significant: standard logs are free (you pay only for S3 storage), while real-time logs incur Kinesis Data Streams charges based on the number of records and shards. For a high-traffic distribution processing millions of requests per hour, real-time log costs can reach hundreds of dollars per month.
+
+| Log type | Delivery latency | Cost | Use case |
+| --- | --- | --- | --- |
+| **Standard logs** | Minutes (batch delivery to S3) | Free (S3 storage only) | Post-incident analysis, trend reporting, compliance archival |
+| **Real-time logs** | Seconds (Kinesis Data Streams) | Kinesis shard-hours + per-record charges | Live dashboards, sub-minute alerting, deployment monitoring |
+
+Choose real-time logs when the operational value of seconds-level visibility justifies the Kinesis cost — typically for high-traffic, revenue-critical distributions where a cache misconfiguration or origin failure must be detected in under a minute.
+
+#### Correlate CloudFront logs with ALB logs for full-path latency analysis
+
+A single client request that traverses CloudFront → ALB → target generates log entries at both layers. CloudFront logs capture the total time the client waited (including edge processing, origin fetch, and network transit). ALB logs capture the time the target took to respond. The difference between CloudFront's total time and ALB's target processing time is the network and edge overhead.
+
+Use the `x-amz-cf-id` request ID (present in both CloudFront logs and the `X-Amz-Cf-Id` header forwarded to the origin) to correlate entries across layers. This correlation reveals whether latency problems are at the edge (CloudFront processing, TLS negotiation), in transit (network path between edge and origin), or at the target (application processing time).
+
+#### Log IPv6 client addresses for complete client visibility
+
+Both ALB and CloudFront log the actual client IPv6 address when clients connect over IPv6. This is not a translated or proxied address — it's the real client IP. For dual-stack deployments, your log analysis must handle both IPv4 and IPv6 addresses in the client IP field.
+
+NLB access logs similarly capture IPv6 client addresses for dual-stack or IPv6-only listeners. Ensure your log parsing, IP-based analytics, and security investigation tools support IPv6 address formats. Geographic IP databases and threat intelligence feeds must cover IPv6 ranges to maintain the same analytical capability you have for IPv4 clients.
+
+***Key insight:*** *As IPv6 client adoption grows, any log analysis pipeline that only handles IPv4 addresses creates a blind spot. Validate IPv6 support in your SIEM, dashboards, and alerting rules.*
+
+### Security observability
+
+#### Enable WAF logging for every web ACL — not just during incidents
+
+AWS WAF logs capture the full evaluation result for every request: which rules were evaluated, which matched, what action was taken, and the request attributes (headers, URI, query string) that triggered the match. This data is essential for three purposes: tuning rules to reduce false positives, investigating attack patterns after the fact, and validating that new rules behave as expected before switching from Count to Block.
+
+WAF logs can be delivered to S3, CloudWatch Logs, or Kinesis Data Firehose. For most environments, deliver to S3 in the centralized logging account for cost-effective long-term storage and Athena-based analysis. Use CloudWatch Logs only when you need real-time metric filters and alarms on specific rule matches (the per-GB ingestion cost is significantly higher than S3).
+
+#### Detect DDoS patterns before Shield Advanced triggers
+
+CloudFront and ALB access logs contain the raw signal that precedes a DDoS event: sudden spikes in request rate from concentrated IP ranges, unusual geographic distribution shifts, or abnormal request patterns (identical User-Agent strings, repeated paths). By monitoring these patterns in near-real-time, you can detect application-layer attacks before they reach the threshold where Shield Advanced's automatic mitigation activates.
+
+Build CloudWatch alarms on ALB request count and 4xx/5xx rates with short evaluation periods (1-minute intervals). For CloudFront, use real-time logs with a Kinesis consumer that tracks request rate by client IP prefix and triggers alerts on anomalous concentration. These early-warning signals give your operations team time to tighten WAF rate limits or engage AWS Shield Response Team before the attack fully develops.
+
+#### Use Route 53 query logs to detect reconnaissance and validate failover
+
+Route 53 query logs for public hosted zones capture every DNS query: the queried domain, query type, resolver IP, and response code. This data reveals reconnaissance patterns (systematic enumeration of subdomains), validates that DNS failover is working as expected during incidents, and provides baseline query volumes for anomaly detection.
+
+Query logs are delivered to CloudWatch Logs in the us-east-1 Region (regardless of where the hosted zone is queried from). For multi-account environments, configure query logging on all public hosted zones and forward the CloudWatch Logs to your centralized logging account using cross-account log subscriptions.
+
+### Egress observability
+
+#### Monitor NAT Gateway metrics for egress cost visibility
+
+NAT Gateway CloudWatch metrics are the primary tool for understanding and controlling egress costs. The key metrics:
+
+| Metric | What it reveals | Alert threshold guidance |
+| --- | --- | --- |
+| `BytesOutToDestination` | Total bytes sent to external destinations (your egress bill) | Baseline + percentage deviation |
+| `BytesOutToSource` | Total bytes returned to your workloads (response traffic) | Unusual ratio to BytesOut suggests data download patterns |
+| `ConnectionAttemptCount` | New connections initiated per period | Spike indicates new workload behavior or compromise |
+| `ActiveConnectionCount` | Concurrent active connections | Approaching 55,000 per-AZ limit signals scaling need |
+| `PacketsDropCount` | Packets dropped due to NAT Gateway limits | Any non-zero value requires investigation |
+| `ErrorPortAllocation` | Port allocation failures (source port exhaustion) | Any non-zero value — workload is exceeding connection limits |
+| `IdleTimeoutCount` | Connections closed due to idle timeout | High values suggest connection pooling issues |
+
+Set CloudWatch alarms on `PacketsDropCount` and `ErrorPortAllocation` with a threshold of 1 — any occurrence means traffic is being silently dropped. Alarm on `BytesOutToDestination` with a percentage-over-baseline threshold to catch unexpected egress cost increases before the monthly bill arrives.
+
+#### Use VPC Flow Logs to identify unexpected egress destinations
+
+VPC Flow Logs capture source and destination IPs for every flow, including egress traffic. When combined with NAT Gateway metrics showing unexpected egress volume, Flow Logs answer the critical follow-up question: *where is that traffic going?*
+
+Configure Flow Logs on the NAT Gateway's ENI or on the subnets that route through it. Use the `dstaddr` field to identify external destination IPs, and correlate with DNS query logs to map IPs back to domain names. This combination reveals which workloads are calling which external services and how much data they're transferring — essential for both cost attribution and security investigation.
+
+#### Track Global Accelerator flow logs for L4 ingress patterns
+
+AWS Global Accelerator flow logs provide the same visibility for L4 traffic that ALB access logs provide for L7: source and destination IPs, ports, protocol, bytes, and packets for every flow through the accelerator. Enable flow logs on every Global Accelerator accelerator that serves production traffic.
+
+Flow logs are delivered to S3 and follow the same format as VPC Flow Logs, making them compatible with existing log analysis pipelines. Use them to understand client geographic distribution, detect connection anomalies, and measure traffic volume per endpoint group.
+
+### Multi-account logging architecture
+
+#### Centralize all external traffic logs in a dedicated logging account
+
+In a multi-account environment, external traffic logs from every account must flow to a centralized logging account for correlation, long-term retention, and cross-account investigation. The logging account is a restricted-access account that application teams cannot modify — ensuring log integrity and retention compliance.
+
+Configure cross-account delivery for each log type:
+
+| Log source | Cross-account delivery mechanism |
+| --- | --- |
+| **ALB/NLB access logs** | S3 bucket policy allowing the ELB service principal for each Region |
+| **CloudFront standard logs** | S3 bucket policy allowing the CloudFront service principal |
+| **CloudFront real-time logs** | Kinesis Data Streams in the logging account (or same account with cross-account IAM) |
+| **WAF logs** | Kinesis Data Firehose to S3 in the logging account, or direct S3 delivery |
+| **VPC Flow Logs** | Cross-account delivery to S3 or CloudWatch Logs with resource policies |
+| **Route 53 query logs** | CloudWatch Logs cross-account subscription filters to centralized destination |
+| **Global Accelerator flow logs** | S3 bucket policy allowing the Global Accelerator service principal |
+
+#### Partition logs for efficient querying
+
+External traffic logs at scale generate terabytes per day. Without proper partitioning, Athena queries scan the entire dataset and cost grows linearly with retention. Partition all log buckets by:
+
+- **Account ID** — enables per-account cost attribution and scoped investigation
+- **Region** — matches the geographic scope of most queries
+- **Year/Month/Day/Hour** — enables time-bounded queries that scan only relevant partitions
+
+ALB and CloudFront logs are already delivered with date-based prefixes. Add account ID as a top-level prefix in your bucket structure. Use Athena partition projection to avoid manual partition management as new data arrives.
+
+***Key insight:*** *The cost of storing external traffic logs is trivial compared to the cost of querying them inefficiently. Invest in partitioning and projection upfront — it determines whether your logs are practically queryable or just an archive.*
+
+### Cost management
+
+#### Understand the cost profile of each data source
+
+External traffic monitoring costs vary by orders of magnitude depending on which data sources you enable and how you consume them:
+
+| Data source | Generation cost | Storage/delivery cost | Analysis cost |
+| --- | --- | --- | --- |
+| **ALB access logs** | Free | S3 storage only (~$0.023/GB/month standard) | Athena per-query scanning |
+| **NLB access logs** | Free | S3 storage only | Athena per-query scanning |
+| **CloudFront standard logs** | Free | S3 storage only | Athena per-query scanning |
+| **CloudFront real-time logs** | Free | Kinesis Data Streams shard-hours + per-record | Consumer compute (Lambda, KDA) |
+| **WAF logs (S3)** | Free | S3 storage only | Athena per-query scanning |
+| **WAF logs (CloudWatch)** | Free | CloudWatch Logs ingestion ($0.50/GB) + storage | CloudWatch Insights queries |
+| **NAT Gateway metrics** | Free (included) | N/A (CloudWatch default retention) | CloudWatch dashboard/alarm cost |
+| **VPC Flow Logs (S3)** | $0.25/GB (first 10 TB) | S3 storage | Athena per-query scanning |
+| **Route 53 query logs** | Free | CloudWatch Logs ingestion + storage | CloudWatch Insights queries |
+
+The highest-cost items are VPC Flow Logs at volume (generation charge) and CloudFront real-time logs (Kinesis charges). For VPC Flow Logs, use custom formats that capture only the fields you need, and filter to capture only rejected traffic or traffic to/from specific ENIs when full capture is not required.
+
+#### Use batch analysis as the default, real-time only where justified
+
+Real-time log analysis (CloudFront real-time logs → Kinesis → Lambda/KDA, or WAF logs → CloudWatch Logs → metric filters) costs significantly more than batch analysis (logs → S3 → Athena on demand). Default to batch analysis for:
+
+- Post-incident investigation
+- Weekly/monthly trend reporting
+- Cost attribution and chargeback
+- Compliance and audit queries
+
+Reserve real-time analysis for:
+
+- Live operational dashboards during deployments
+- Sub-minute alerting on error rate spikes
+- Active incident response where seconds matter
+- DDoS detection and automated response triggers
+
+## When to use each data source
+
+Each data source answers different questions. The right combination depends on what you need to know and how quickly you need to know it.
+
+**CloudFront access logs** are the right choice when:
+
+* You need client-experience metrics (latency, cache hit ratio, error rates at the edge)
+* You want geographic distribution of client traffic
+* You need to understand cache behavior and optimize cache policies
+* You're investigating edge-level issues (TLS negotiation failures, HTTP protocol errors)
+
+**ALB access logs** are the right choice when:
+
+* You need per-request visibility into target behavior (which target served which request, how long it took)
+* You're debugging 5xx errors and need to distinguish load-balancer errors from target errors
+* You need client IP correlation with specific requests for security investigation
+* You want latency percentile analysis at the request level
+
+**NLB access logs** are the right choice when:
+
+* You need connection-level visibility for L4 workloads (connection duration, bytes per connection)
+* You're debugging TLS handshake failures or cipher negotiation issues
+* You need to understand connection patterns for capacity planning
+
+**AWS WAF logs** are the right choice when:
+
+* You're investigating blocked requests to determine if they're legitimate (false positives)
+* You need to tune WAF rules based on actual match data
+* You're correlating attack patterns across time to identify persistent threats
+* You need audit evidence of security decisions made on each request
+
+**NAT Gateway metrics** are the right choice when:
+
+* You need egress cost visibility and trending
+* You're detecting unexpected outbound traffic volume
+* You need to monitor for connection limits and port exhaustion
+* You want early warning of workload behavior changes that affect egress spend
+
+**Route 53 query logs** are the right choice when:
+
+* You need to validate DNS failover behavior during incidents
+* You're detecting subdomain enumeration or reconnaissance
+* You want baseline query volumes for anomaly detection
+* You need to understand DNS-level traffic distribution across endpoints
+
+**Global Accelerator flow logs** are the right choice when:
+
+* You need client-to-accelerator traffic visibility for L4 workloads
+* You're analyzing geographic client distribution for accelerator endpoint placement
+* You need flow-level data for capacity planning on accelerator endpoints
+
+## Combining external traffic monitoring with other services
+
+| Combination | External traffic monitoring provides | Other service provides |
+| --- | --- | --- |
+| **ALB access logs + Amazon Athena** | Per-request log data in S3 | SQL-based ad-hoc querying with partition pruning for cost-efficient analysis |
+| **CloudFront real-time logs + Kinesis Data Streams + Lambda** | Per-request edge data in real time | Stream processing for live dashboards, anomaly detection, and automated response |
+| **WAF logs + Amazon OpenSearch Service** | Per-request security evaluation data | Full-text search, visualization, and correlation for security investigation |
+| **NAT Gateway metrics + CloudWatch Alarms + SNS** | Egress volume and connection metrics | Threshold-based alerting and notification routing to operations teams |
+| **VPC Flow Logs + Amazon Athena** | Per-flow network data including egress destinations | Destination analysis, cost attribution, and security investigation queries |
+| **Route 53 query logs + CloudWatch Logs Insights** | DNS query patterns for public zones | Pattern analysis, anomaly detection, and failover validation queries |
+| **ALB access logs + AWS Security Hub** | Request-level evidence of attacks | Centralized security findings aggregation and compliance reporting |
+| **CloudFront logs + Amazon QuickSight** | Client experience and cache performance data | Business intelligence dashboards for stakeholder reporting |
+| **All log sources + AWS Glue + S3** | Raw log data from every layer | Schema discovery, ETL, and data lake organization for cross-layer correlation |
+
+## Client experience monitoring
+
+External traffic logs are the only source of truth for how real clients experience your application. CloudWatch metrics on your targets show server-side health; external traffic logs show client-side reality.
+
+### Latency percentiles from ALB logs
+
+ALB access logs include `target_processing_time` (time the target took to respond), `request_processing_time` (time ALB spent before forwarding), and `response_processing_time` (time ALB spent sending the response). Use these fields to compute latency percentiles (p50, p95, p99) that reveal the tail-latency experience your slowest clients face — something average-based CloudWatch metrics hide.
+
+Query ALB logs with Athena to compute percentiles per target group, per target, or per URL path. A p99 that's 10x the p50 indicates a subset of requests hitting a slow path — often a cold cache, a specific target, or a particular request pattern.
+
+### Cache hit ratios from CloudFront logs
+
+CloudFront logs include the `x-edge-result-type` field that indicates whether each request was served from cache (Hit), fetched from origin (Miss), or resulted in an error. Compute cache hit ratio as the percentage of requests served as Hit or RefreshHit versus total requests.
+
+A dropping cache hit ratio directly increases origin load and client latency. Monitor this metric after deployments (new cache behaviors or invalidations can tank hit rates), after TTL changes, and during traffic pattern shifts. CloudFront's built-in cache statistics in the console provide aggregate views; log-based analysis gives you per-path and per-geographic breakdown.
+
+### IPv6 client adoption tracking
+
+CloudFront and ALB logs both record the client's IP version. Track the percentage of requests arriving over IPv6 versus IPv4 to measure your IPv6 client adoption over time. This data informs decisions about IPv6-only infrastructure (when IPv6 clients reach a threshold, IPv4 infrastructure becomes the legacy path rather than the default).
+
+## Documentation
+
+<div class="grid cards" markdown>
+
+*   :material-file-document: **CloudFront access logs**
+
+    ---
+
+    Standard and real-time logging for CloudFront distributions, including log fields, delivery configuration, and S3/Kinesis setup.
+
+    [:octicons-arrow-right-24: CloudFront logging documentation](https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html)
+
+*   :material-file-document: **ALB access logs**
+
+    ---
+
+    Per-request logging for Application Load Balancers, including log format, S3 delivery, and cross-account configuration.
+
+    [:octicons-arrow-right-24: ALB access log documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-access-logs.html)
+
+*   :material-file-document: **NLB access logs**
+
+    ---
+
+    Connection-level logging for Network Load Balancers, including TLS metadata and connection timing fields.
+
+    [:octicons-arrow-right-24: NLB access log documentation](https://docs.aws.amazon.com/elasticloadbalancing/latest/network/load-balancer-access-logs.html)
+
+*   :material-file-document: **AWS WAF logging**
+
+    ---
+
+    Per-request WAF evaluation logging to S3, CloudWatch Logs, or Kinesis Data Firehose, including log field reference and filtering.
+
+    [:octicons-arrow-right-24: WAF logging documentation](https://docs.aws.amazon.com/waf/latest/developerguide/logging.html)
+
+*   :material-currency-usd: **CloudWatch pricing**
+
+    ---
+
+    Pricing for metrics, alarms, logs ingestion, and Logs Insights queries that drive the cost of real-time monitoring.
+
+    [:octicons-arrow-right-24: CloudWatch pricing](https://aws.amazon.com/cloudwatch/pricing/)
+
+*   :material-file-document: **NAT Gateway monitoring**
+
+    ---
+
+    CloudWatch metrics available for NAT Gateways, including dimensions, statistics, and recommended alarms.
+
+    [:octicons-arrow-right-24: NAT Gateway CloudWatch metrics](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway-cloudwatch.html)
+
+</div>
+
+## Related pages
+
+**Relationship to other Observability topics:**
+
+- **[Internal Traffic Monitoring](internal-traffic.md)**: Covers east-west traffic visibility within your AWS environment. External traffic monitoring handles north-south flows crossing the internet boundary.
+- **[AWS Services Monitoring](service-monitoring.md)**: Covers health and performance monitoring of AWS networking services themselves. External traffic monitoring uses the data those services produce.
+- **[Notifications](notifications.md)**: Covers alerting and notification routing. External traffic monitoring generates the signals that notifications act on.
+
+**Relationship to Connectivity:**
+
+- **[Internet Connectivity](../connectivity/internet.md)**: Defines the ingress and egress architecture (centralized vs. decentralized, IPv4 vs. IPv6). External traffic monitoring provides visibility into how that architecture performs in production.
+
+**Relationship to Application Networking:**
+
+- **[Load Balancing](../application-networking/load-balancing.md)**: ALB and NLB are both the data plane for ingress traffic and the source of access logs that drive external traffic observability.
+
+**Relationship to Security:**
+
+- **[Outbound Controls](../security/outbound.md)**: Defines what egress traffic is allowed. External traffic monitoring (NAT Gateway metrics, VPC Flow Logs) validates that those controls are working and reveals policy gaps.

--- a/content/observability/index.md
+++ b/content/observability/index.md
@@ -1,6 +1,68 @@
 # Observability
 
-Monitor, analyze, and troubleshoot your network traffic and services. Learn how to gain visibility into your AWS networking infrastructure and application performance.
+This section covers how to gain visibility into your AWS network — what traffic is flowing, whether the services carrying that traffic are healthy, and how to get notified when something goes wrong. Network observability is not a single dashboard; it is a layered approach where each data source answers different questions, and the combination gives you the full picture.
+
+Observability operates on top of the connectivity, application networking, and security layers. It consumes the logs, metrics, and events those layers produce and turns them into actionable insight. Without observability, you're operating blind: unable to troubleshoot connectivity failures, unable to detect security incidents, unable to attribute costs, and unable to validate that your architecture is performing as designed.
+
+## 1. Internal Traffic Monitoring
+
+**Internal traffic monitoring** provides visibility into traffic flows between resources within your AWS environment — VPC-to-VPC, subnet-to-subnet, ENI-to-ENI. This is the foundation of network security analysis, cost attribution, and connectivity troubleshooting.
+
+**Key data sources:**
+
+*   **VPC Flow Logs** — Packet-level metadata at VPC, subnet, or ENI level with 40+ custom format fields
+*   **Transit Gateway Flow Logs** — Centralized cross-VPC and cross-account traffic visibility from a single configuration
+*   **VPC Lattice Access Logs** — Per-request service-to-service detail with identity, latency, and auth decisions
+*   **Network Firewall Logs** — Stateful inspection decisions (allowed, denied, alerted) with rule attribution
+*   **Amazon Athena** — SQL-based querying of Flow Logs stored in S3 for large-scale analysis
+
+***Key insight:*** *VPC Flow Logs are not optional in production. They are the network equivalent of application logging — without them, you cannot investigate security incidents, troubleshoot connectivity issues, or understand your actual traffic patterns.*
+
+## 2. External Traffic Monitoring
+
+**External traffic monitoring** covers visibility into traffic crossing the boundary between your AWS environment and the public internet — both ingress from clients and egress to external services. Each layer captures what the others cannot see.
+
+**Key data sources:**
+
+*   **CloudFront access logs / real-time logs** — Edge-level client experience (latency, cache status, protocol, geographic distribution)
+*   **ALB / NLB access logs** — Per-request or per-connection detail (target latency, response codes, TLS metadata)
+*   **AWS WAF logs** — Security evaluation results (rule matches, allow/block decisions, request attributes)
+*   **NAT Gateway CloudWatch metrics** — Egress volume, connection counts, port exhaustion, packet drops
+*   **Route 53 query logs** — DNS query patterns for public hosted zones
+
+***Key insight:*** *ALB access logs are free to generate, cost pennies to store, and are irreplaceable during incident investigation. There is no valid reason to leave them disabled on a production ALB.*
+
+## 3. AWS Services Monitoring
+
+**AWS services monitoring** focuses on the operational health of the networking services themselves — not the traffic flowing through them, but whether the infrastructure carrying that traffic is healthy. A Transit Gateway with blackhole drops, a NAT Gateway exhausting its port allocation, or a Direct Connect connection flapping are service-level failures that traffic monitoring alone won't catch.
+
+**Key patterns:**
+
+*   **Critical metrics per service** — The specific CloudWatch metrics that signal real operational problems for Transit Gateway, NAT Gateway, Direct Connect, VPN, ALB, NLB, Network Firewall, and VPC Lattice
+*   **Composite alarms** — Combine multiple signals to confirm real problems before paging (reduce alert fatigue)
+*   **Anomaly detection** — ML-based alerting that adapts to traffic patterns without manual threshold tuning
+*   **Quota monitoring** — Alarm at 80% utilization before hitting service limits
+*   **Centralized dashboards** — Cross-account, cross-Region visibility for the networking team
+
+***Key insight:*** *CloudWatch metrics tell you the service is healthy. Synthetic health checks tell you the path works end-to-end. You need both — a healthy service with broken routing still means an outage.*
+
+## 4. Notifications
+
+**Notifications** bridge the gap between detecting a problem and getting the right person to act on it. The number one operational failure in monitoring is alert fatigue — teams ignoring alerts because too many are false positives or low-priority noise.
+
+**Key services:**
+
+*   **CloudWatch Alarms** — Metric-based alerting with thresholds, anomaly detection, and composite alarms
+*   **Amazon EventBridge** — Event-driven notifications for state changes (VPN tunnel down, Direct Connect flap, BGP session lost)
+*   **Amazon SNS** — Fan-out delivery to email, PagerDuty, Lambda, SQS
+*   **AWS Health Dashboard** — Proactive awareness of AWS service events affecting your resources
+*   **AWS Chatbot** — Deliver alarms to Slack and Microsoft Teams with interactive actions
+
+***Key insight:*** *If your team routinely ignores alarms, you don't have a monitoring problem — you have an alarm design problem. Every alarm must have a clear owner and a defined response action.*
+
+---
+
+## Explore Observability Topics
 
 <div class="grid cards" markdown>
 
@@ -8,9 +70,7 @@ Monitor, analyze, and troubleshoot your network traffic and services. Learn how 
 
     ---
 
-    Monitor traffic flows between resources within your AWS environment.
-
-    ---
+    VPC Flow Logs, Transit Gateway Flow Logs, VPC Lattice access logs, Athena integration, and cost-effective log analysis.
 
     [:octicons-arrow-right-24: Internal Traffic Monitoring](internal-traffic.md)
 
@@ -18,9 +78,7 @@ Monitor, analyze, and troubleshoot your network traffic and services. Learn how 
 
     ---
 
-    Track and analyze traffic between your AWS resources and the internet.
-
-    ---
+    CloudFront logs, ALB/NLB access logs, WAF logs, NAT Gateway metrics, and client experience monitoring.
 
     [:octicons-arrow-right-24: External Traffic Monitoring](external-traffic.md)
 
@@ -28,9 +86,7 @@ Monitor, analyze, and troubleshoot your network traffic and services. Learn how 
 
     ---
 
-    Monitor the health and performance of AWS networking services.
-
-    ---
+    Critical metrics per service, composite alarms, anomaly detection, centralized dashboards, and automated remediation.
 
     [:octicons-arrow-right-24: AWS Services Monitoring](service-monitoring.md)
 
@@ -38,9 +94,7 @@ Monitor, analyze, and troubleshoot your network traffic and services. Learn how 
 
     ---
 
-    Set up alerts and notifications for network events and anomalies.
-
-    ---
+    Alarm design, severity tiers, composite alarms, EventBridge state-change routing, and cross-account event forwarding.
 
     [:octicons-arrow-right-24: Notifications](notifications.md)
 

--- a/content/observability/internal-traffic.md
+++ b/content/observability/internal-traffic.md
@@ -1,3 +1,424 @@
 # Internal Traffic Monitoring
 
-Content coming soon.
+!!! info "Prerequisites"
+    This section assumes familiarity with [Amazon VPC](../foundation/vpc.md), [Subnets](../foundation/subnets.md), and [Connectivity Within AWS](../connectivity/within-aws.md). Review those topics first if you're new to AWS networking fundamentals.
+
+Understanding what traffic flows between your internal resources is the foundation of network security, cost optimization, and troubleshooting in AWS. Security groups and NACLs define what's *allowed* — internal traffic monitoring tells you what's *actually happening*. Without it, you're operating blind: unable to detect lateral movement, unable to identify unexpected cross-AZ data transfer costs, and unable to troubleshoot connectivity failures beyond "it doesn't work."
+
+Internal traffic monitoring in AWS is not a single tool — it's a layered approach. VPC Flow Logs provide packet-level metadata at the network layer. Transit Gateway Flow Logs give you centralized cross-VPC visibility. VPC Lattice access logs capture per-request application-layer detail. Network Firewall logs record stateful inspection decisions. Each data source answers different questions, and a production environment needs most of them working together.
+
+This page is organized around data sources and the decisions you face when building internal traffic visibility: what to enable, where to send the data, how to query it cost-effectively, and how to correlate across sources.
+
+``` mermaid
+graph TB
+    subgraph DataSources["Internal Traffic Data Sources"]
+        FlowLogs["VPC Flow Logs<br/>Packet metadata at VPC/subnet/ENI"]
+        TGWLogs["Transit Gateway Flow Logs<br/>Cross-VPC and cross-account traffic"]
+        LatticeLogs["VPC Lattice Access Logs<br/>Per-request service-to-service detail"]
+        NFWLogs["Network Firewall Logs<br/>Stateful inspection decisions"]
+    end
+
+    subgraph Destinations["Analysis & Storage"]
+        S3["Amazon S3<br/>Cost-effective long-term storage"]
+        CWLogs["CloudWatch Logs<br/>Real-time querying"]
+        Firehose["Kinesis Data Firehose<br/>Streaming delivery"]
+    end
+
+    subgraph Analysis["Query & Alerting"]
+        Athena["Amazon Athena<br/>SQL over S3 data"]
+        CWInsights["CloudWatch Logs Insights<br/>Real-time log queries"]
+        CWMetrics["CloudWatch Metrics<br/>Network throughput & errors"]
+    end
+
+    FlowLogs --> S3
+    FlowLogs --> CWLogs
+    FlowLogs --> Firehose
+    TGWLogs --> S3
+    TGWLogs --> CWLogs
+    LatticeLogs --> S3
+    LatticeLogs --> CWLogs
+    LatticeLogs --> Firehose
+    NFWLogs --> S3
+    NFWLogs --> CWLogs
+    NFWLogs --> Firehose
+    S3 --> Athena
+    CWLogs --> CWInsights
+    CWLogs --> CWMetrics
+
+    style DataSources fill:none,stroke:#2563eb,stroke-width:2px,stroke-dasharray:5 5,color:#2563eb
+    style Destinations fill:none,stroke:#059669,stroke-width:2px,stroke-dasharray:5 5,color:#059669
+    style Analysis fill:none,stroke:#7c3aed,stroke-width:2px,stroke-dasharray:5 5,color:#7c3aed
+    style FlowLogs fill:#2563eb,stroke:#1e40af,color:#fff
+    style TGWLogs fill:#2563eb,stroke:#1e40af,color:#fff
+    style LatticeLogs fill:#2563eb,stroke:#1e40af,color:#fff
+    style NFWLogs fill:#2563eb,stroke:#1e40af,color:#fff
+    style S3 fill:#059669,stroke:#065f46,color:#fff
+    style CWLogs fill:#059669,stroke:#065f46,color:#fff
+    style Firehose fill:#059669,stroke:#065f46,color:#fff
+    style Athena fill:#7c3aed,stroke:#6d28d9,color:#fff
+    style CWInsights fill:#7c3aed,stroke:#6d28d9,color:#fff
+    style CWMetrics fill:#7c3aed,stroke:#6d28d9,color:#fff
+```
+
+## Key capabilities
+
+<div class="grid cards" markdown>
+
+*   :material-lan: **VPC Flow Logs**
+
+    ---
+
+    Capture IP traffic metadata at the VPC, subnet, or ENI level. Custom log format includes 40+ fields covering source/destination, ports, protocols, TCP flags, traffic path, and flow direction. Supports both IPv4 and IPv6.
+
+*   :material-transit-connection-variant: **Transit Gateway Flow Logs**
+
+    ---
+
+    Centralized view of all traffic crossing your Transit Gateway — cross-VPC, cross-account, and hybrid. One configuration provides org-wide visibility without per-VPC setup.
+
+*   :material-swap-horizontal: **VPC Lattice Access Logs**
+
+    ---
+
+    Per-request logs with caller identity, target identity, latency, response code, and auth policy decisions. Application-layer visibility for service-to-service traffic.
+
+*   :material-shield-check: **Network Firewall Logs**
+
+    ---
+
+    Alert and flow logs from stateful inspection. Records what was allowed, denied, or triggered an alert, with full 5-tuple detail and rule group attribution.
+
+*   :material-database-search: **Amazon Athena**
+
+    ---
+
+    SQL-based querying of Flow Logs stored in S3. The recommended analysis tool for large-scale Flow Log data with partitioned tables and pre-built query patterns.
+
+*   :material-chart-line: **CloudWatch Metrics & Logs Insights**
+
+    ---
+
+    Real-time network metrics (NetworkIn/Out, NAT Gateway bytes, Transit Gateway bytes) and interactive log querying for Flow Logs delivered to CloudWatch Logs.
+
+</div>
+
+## Best Practices
+
+### VPC Flow Logs as the foundation
+
+#### Enable VPC Flow Logs on every VPC in every account
+
+VPC Flow Logs are the single most important internal traffic monitoring tool. Enable them at the VPC level — not subnet or ENI level — to capture all traffic within the VPC with a single configuration. Subnet-level and ENI-level logs are useful for targeted troubleshooting but create coverage gaps when used as the primary mechanism.
+
+In a multi-account environment, deploy Flow Logs as part of your account vending process. Every new VPC should have Flow Logs enabled automatically, delivering to a centralized S3 bucket in your log archive account. This ensures no VPC operates without visibility, regardless of which team created it.
+
+***Key insight:*** *VPC Flow Logs are not optional in production. They are the network equivalent of application logging — without them, you cannot investigate security incidents, troubleshoot connectivity issues, or understand your actual traffic patterns.*
+
+#### Use custom log format for richer metadata
+
+The default Flow Log format captures only 14 fields. The custom format supports 40+ fields that are essential for production analysis. At minimum, include these fields beyond the default:
+
+| Field | Why it matters |
+| --- | --- |
+| `traffic-path` | Identifies the path traffic took (IGW, VGW, Transit Gateway, VPC Peering, etc.) — critical for cost attribution |
+| `flow-direction` | Distinguishes ingress from egress at the ENI level |
+| `pkt-src-addr` / `pkt-dst-addr` | Original source/destination before NAT translation — essential when traffic traverses NAT Gateways |
+| `tcp-flags` | Identifies SYN-only flows (connection attempts), RST (rejected connections), and FIN (clean closures) |
+| `sublocation-type` / `sublocation-id` | Identifies the specific wavelength zone or local zone |
+| `type` | IPv4 or IPv6 — use this to filter and analyze IPv6 traffic patterns |
+| `az-id` | Availability Zone ID — critical for identifying cross-AZ traffic and associated costs |
+
+The `type` field is particularly important for IPv6 visibility. Flow Logs capture both IPv4 and IPv6 traffic in the same log stream. Use the `type` field to filter, analyze adoption rates, and identify workloads that have migrated to IPv6.
+
+#### Deliver Flow Logs to S3 for cost-effective storage and analysis
+
+You have three delivery options: S3, CloudWatch Logs, and Kinesis Data Firehose. For the primary, always-on Flow Log configuration, deliver to S3. The cost difference is significant:
+
+| Delivery destination | Ingestion cost | Storage cost | Query method |
+| --- | --- | --- | --- |
+| **S3** | $0.25 per GB (first 10 TB/month) | S3 storage rates (~$0.023/GB/month) | Athena ($5 per TB scanned) |
+| **CloudWatch Logs** | $0.50 per GB | $0.03 per GB/month | Logs Insights ($0.005 per GB scanned) |
+| **Kinesis Data Firehose** | $0.029 per GB + destination costs | Depends on destination | Depends on destination |
+
+For a VPC generating 100 GB/month of Flow Log data, S3 delivery costs roughly $25/month for ingestion. CloudWatch Logs costs $50/month for the same data. At scale across dozens of VPCs, this difference compounds into thousands of dollars monthly.
+
+Use CloudWatch Logs as a *secondary* destination only when you need real-time alerting on specific traffic patterns (e.g., rejected flows to sensitive subnets). Keep the retention short (7-14 days) to control costs.
+
+#### Partition Flow Log data in S3 for efficient Athena queries
+
+When delivering to S3, use Hive-compatible partitioning with the following structure: `{bucket}/{prefix}/AWSLogs/{account-id}/vpcflowlogs/{region}/{year}/{month}/{day}/`. This is the default delivery structure and enables Athena partition projection, which eliminates the need to run `MSCK REPAIR TABLE` as new partitions arrive.
+
+Create your Athena table with partition projection enabled:
+
+```sql
+CREATE EXTERNAL TABLE vpc_flow_logs (
+  version int,
+  account_id string,
+  interface_id string,
+  srcaddr string,
+  dstaddr string,
+  srcport int,
+  dstport int,
+  protocol bigint,
+  packets bigint,
+  bytes bigint,
+  start bigint,
+  end_time bigint,
+  action string,
+  log_status string,
+  vpc_id string,
+  subnet_id string,
+  tcp_flags int,
+  type string,
+  pkt_srcaddr string,
+  pkt_dstaddr string,
+  az_id string,
+  flow_direction string,
+  traffic_path int
+)
+PARTITIONED BY (
+  `date` string,
+  region string,
+  account_id_partition string
+)
+ROW FORMAT DELIMITED FIELDS TERMINATED BY ' '
+LOCATION 's3://your-flow-logs-bucket/AWSLogs/'
+TBLPROPERTIES (
+  'projection.enabled' = 'true',
+  'projection.date.type' = 'date',
+  'projection.date.range' = '2024/01/01,NOW',
+  'projection.date.format' = 'yyyy/MM/dd',
+  'projection.date.interval' = '1',
+  'projection.date.interval.unit' = 'DAYS',
+  'projection.region.type' = 'enum',
+  'projection.region.values' = 'us-east-1,us-west-2,eu-west-1',
+  'projection.account_id_partition.type' = 'enum',
+  'projection.account_id_partition.values' = '111111111111,222222222222'
+);
+```
+
+This approach means Athena queries only scan the partitions you specify, reducing both query time and cost dramatically.
+
+### Transit Gateway Flow Logs for cross-VPC visibility
+
+#### Enable Transit Gateway Flow Logs for organization-wide traffic visibility
+
+Transit Gateway Flow Logs capture traffic at the Transit Gateway level — every packet crossing between VPCs, between accounts, or between your AWS network and on-premises. This provides a single, centralized view of cross-VPC traffic without requiring per-VPC Flow Log configuration in every account.
+
+This is particularly valuable in multi-account environments where you may not have direct access to enable VPC Flow Logs in every workload account. Transit Gateway Flow Logs are configured in the networking account that owns the Transit Gateway, giving the networking team visibility into all cross-VPC traffic patterns regardless of workload account configurations.
+
+#### Use Transit Gateway Flow Logs to detect unauthorized cross-VPC communication
+
+Transit Gateway route tables and attachments define what *can* communicate. Transit Gateway Flow Logs show what *does* communicate. Compare the two to identify:
+
+- Traffic between VPCs that should be isolated (e.g., production to development)
+- Unexpected traffic volumes between specific VPC pairs (potential data exfiltration)
+- Traffic patterns that indicate misconfigured route tables (traffic taking unexpected paths)
+
+***Key insight:*** *Transit Gateway Flow Logs are the only native way to get a single-pane view of all cross-VPC traffic in your organization without configuring Flow Logs in every individual VPC. For networking teams managing hundreds of accounts, this is the starting point for cross-VPC visibility.*
+
+### Choosing delivery destinations
+
+#### Match the delivery destination to the use case
+
+The choice between S3, CloudWatch Logs, and Kinesis Data Firehose is not about preference — it's about what you need to do with the data:
+
+| Use case | Recommended destination | Rationale |
+| --- | --- | --- |
+| Long-term retention and compliance | S3 | Lowest storage cost, lifecycle policies for archival, Athena for ad-hoc queries |
+| Real-time alerting on traffic patterns | CloudWatch Logs | Metric filters and alarms trigger within minutes of log delivery |
+| Security incident investigation | S3 + Athena | SQL queries across months of data, partition pruning for fast results |
+| Streaming to SIEM or third-party tools | Kinesis Data Firehose | Real-time delivery to Splunk, Datadog, or custom consumers |
+| Cost-optimized daily reporting | S3 + Athena scheduled queries | Run queries on a schedule, store results in a reporting table |
+
+Most organizations should use S3 as the primary destination for all Flow Logs, with CloudWatch Logs as a secondary destination only for VPCs or accounts where real-time alerting is required.
+
+#### Centralize Flow Log delivery in a dedicated log archive account
+
+In a multi-account environment, deliver all Flow Logs to a centralized S3 bucket in your log archive account. This provides:
+
+- Single location for security investigations across all accounts
+- Consistent retention policies applied organization-wide
+- Cross-account Athena queries without switching roles
+- Simplified compliance auditing (one bucket to demonstrate log completeness)
+
+Configure cross-account Flow Log delivery using a bucket policy that allows the Flow Logs service (`delivery.logs.amazonaws.com`) to write from any account in your organization. Use the `aws:PrincipalOrgID` condition to restrict access to your organization only.
+
+### Network Firewall log analysis
+
+#### Enable both alert and flow logs on Network Firewall
+
+AWS Network Firewall produces two log types: alert logs (traffic that matched a stateful rule with an alert or drop action) and flow logs (all traffic evaluated by the stateful engine). Enable both.
+
+Alert logs tell you what was blocked or flagged. Flow logs tell you what was allowed through. Together, they provide complete visibility into the firewall's decisions. Without flow logs, you only see problems — you can't confirm that legitimate traffic is flowing correctly or identify traffic that should be inspected but isn't matching any rule.
+
+#### Correlate Network Firewall logs with VPC Flow Logs for full context
+
+Network Firewall logs include the 5-tuple (source IP, destination IP, source port, destination port, protocol) but lack VPC-level context like subnet ID, instance ID, or ENI ID. VPC Flow Logs provide that context. Correlating the two gives you the complete picture: which specific resource initiated the traffic, what path it took, and what the firewall decided to do with it.
+
+Use the timestamp and 5-tuple as the correlation key. Athena queries that join Flow Log and Network Firewall log tables on these fields are the most effective approach for incident investigation.
+
+### IPv6 traffic visibility
+
+#### Use the same Flow Logs for IPv4 and IPv6 — no separate configuration needed
+
+VPC Flow Logs capture both IPv4 and IPv6 traffic in the same log stream. You do not need separate Flow Log configurations for IPv6. The `type` field in the custom log format distinguishes between IPv4 (`3`) and IPv6 (`6`) flows.
+
+Include the `type` field in your custom log format to enable filtering. Common use cases:
+
+- Track IPv6 adoption rate across your VPCs (ratio of type=6 to type=3 flows)
+- Identify workloads that have migrated to IPv6 and validate they're no longer using IPv4
+- Detect unexpected IPv6 traffic in VPCs where IPv6 is not yet intentionally deployed
+
+#### Include IPv6-specific fields in your custom log format
+
+When using dual-stack VPCs, include `pkt-srcaddr` and `pkt-dstaddr` in your custom format. These fields show the original packet addresses before any translation, which is essential when traffic traverses NAT64 or other translation mechanisms. The standard `srcaddr`/`dstaddr` fields show the post-translation addresses at the ENI, while `pkt-srcaddr`/`pkt-dstaddr` show what was on the wire.
+
+### Cost optimization
+
+#### Understand the cost model before scaling Flow Log collection
+
+Flow Log costs have three components: ingestion, storage, and analysis. At scale, these add up:
+
+- **Ingestion**: The per-GB charge for delivering logs to the destination. S3 is cheapest ($0.25/GB for first 10 TB), CloudWatch Logs is 2x ($0.50/GB).
+- **Storage**: S3 Standard is $0.023/GB/month. Use S3 Intelligent-Tiering or lifecycle rules to move older logs to Glacier after 90 days.
+- **Analysis**: Athena charges $5 per TB scanned. Partitioning and columnar formats (Parquet via Firehose) reduce scan volume dramatically.
+
+For a 100-VPC environment generating 1 TB/month of Flow Logs, the baseline cost is approximately $250/month for S3 ingestion + $23/month for storage. CloudWatch Logs for the same volume would be $500/month for ingestion + $30/month for storage. Over a year, the S3 approach saves roughly $3,000 — and the gap widens as you retain more history.
+
+#### Use aggregation intervals to reduce volume without losing visibility
+
+Flow Logs support 1-minute and 10-minute aggregation intervals. The 10-minute interval produces significantly less data (flows are aggregated over longer windows), reducing both ingestion and storage costs. Use 10-minute intervals for general visibility and compliance. Use 1-minute intervals only for VPCs where you need near-real-time detection of traffic anomalies.
+
+#### Convert Flow Logs to Parquet format for cheaper Athena queries
+
+Athena charges per TB scanned. Parquet format is columnar and compressed, reducing scan volume by 80-90% compared to raw text logs. Use Kinesis Data Firehose with format conversion to deliver Flow Logs directly in Parquet format to S3. This increases ingestion cost slightly (Firehose processing charges) but dramatically reduces ongoing Athena query costs — which matters more for data you'll query repeatedly over months.
+
+***Key insight:*** *The cheapest Flow Log is one you never query. Deliver everything to S3 for compliance and incident response, but invest in Parquet conversion and partitioning for the data you query regularly. The upfront effort in data engineering pays for itself within weeks at scale.*
+
+## When to use each data source
+
+Each internal traffic monitoring tool answers different questions. Using the wrong tool for the question wastes time and money.
+
+| Question | Best data source | Why |
+| --- | --- | --- |
+| "What IPs is this instance talking to?" | VPC Flow Logs (ENI-level) | Provides per-interface traffic metadata with source/destination |
+| "Is traffic flowing between VPC A and VPC B?" | Transit Gateway Flow Logs | Centralized cross-VPC view without per-VPC configuration |
+| "Why is Service A getting 500 errors from Service B?" | VPC Lattice Access Logs | Per-request detail with response codes, latency, and identity |
+| "What did the firewall block in the last hour?" | Network Firewall Alert Logs | Records every drop/alert action with rule attribution |
+| "How much cross-AZ traffic is this VPC generating?" | VPC Flow Logs + `az-id` field | The `az-id` field identifies which AZ each flow originates from |
+| "Which accounts are generating the most inter-VPC traffic?" | Transit Gateway Flow Logs | Account-level attribution for all Transit Gateway traffic |
+| "Was this request authorized by the auth policy?" | VPC Lattice Access Logs | Logs include auth policy decision (allow/deny) and principal |
+| "What's the total network throughput for this instance?" | CloudWatch Metrics (NetworkIn/Out) | Pre-aggregated metrics without log parsing |
+| "Is IPv6 traffic flowing in this VPC?" | VPC Flow Logs + `type` field | Filter on type=6 to isolate IPv6 flows |
+
+VPC Lattice access logs and VPC Flow Logs are complementary, not alternatives. Lattice logs tell you *what happened at the application layer* (which service called which, with what identity, and what the response was). Flow Logs tell you *what happened at the network layer* (which IPs exchanged packets, how many bytes, whether the traffic was accepted or rejected by security groups). For service-to-service traffic flowing through VPC Lattice, use both to get full request-to-packet visibility.
+
+## Combining internal traffic monitoring with other services
+
+| Combination | Internal traffic monitoring provides | Other service provides |
+| --- | --- | --- |
+| **Flow Logs + Amazon GuardDuty** | Raw traffic metadata for custom analysis | Automated threat detection using Flow Logs as a data source (DNS-based, port probe, crypto mining) |
+| **Flow Logs + AWS Security Hub** | Evidence for security findings | Aggregated security posture with findings from multiple sources |
+| **Flow Logs + Amazon Detective** | Historical traffic data for investigation | Graph-based visualization of entity relationships during incident response |
+| **Flow Logs + AWS Cost Explorer** | Traffic volume data for cost attribution | Cost breakdowns by service, showing data transfer charges |
+| **Transit Gateway Flow Logs + AWS Network Manager** | Per-flow traffic detail | Topology visualization and route analysis for Transit Gateway and Cloud WAN |
+| **VPC Lattice Logs + AWS X-Ray** | Network-level request logging with auth decisions | Distributed tracing across services for latency analysis |
+| **Network Firewall Logs + AWS Firewall Manager** | Per-firewall inspection decisions | Centralized firewall policy management across accounts |
+| **Flow Logs + Amazon CloudWatch** | Detailed per-flow records | Aggregated metrics, dashboards, and alarms for network health |
+
+***Key insight:*** *Internal traffic monitoring data is most valuable when it feeds other services. GuardDuty consumes Flow Logs automatically. Detective uses them for investigation graphs. Cost Explorer correlates with data transfer charges. Enable the data sources first, then layer analysis services on top — the data has compounding value across your security and operations tooling.*
+
+## Multi-account deployment patterns
+
+### Centralized log aggregation
+
+In an AWS Organizations environment, deploy a centralized logging architecture:
+
+1. **Log archive account** owns the S3 bucket where all Flow Logs are delivered
+2. **Networking account** owns Transit Gateway Flow Logs and Network Firewall logs
+3. **Workload accounts** deliver VPC Flow Logs cross-account to the centralized bucket
+4. **Security account** runs Athena queries and CloudWatch dashboards against the centralized data
+
+Configure the S3 bucket policy to accept Flow Log delivery from any account in your organization using the `aws:PrincipalOrgID` condition. This scales automatically as new accounts are added — no bucket policy updates required per account.
+
+### Cross-account Flow Log delivery
+
+VPC Flow Logs support cross-account delivery to S3 natively. The Flow Log in the source account specifies the destination S3 bucket ARN in the log archive account. The bucket policy grants `delivery.logs.amazonaws.com` permission to write, conditioned on the organization ID. No additional IAM roles or cross-account trust relationships are needed beyond the bucket policy.
+
+For CloudWatch Logs delivery, cross-account requires a CloudWatch Logs destination in the receiving account with a resource policy allowing the source accounts. This is more complex to manage and is generally not recommended for large-scale centralized logging — use S3 instead.
+
+### Transit Gateway Flow Logs for org-wide visibility
+
+Transit Gateway Flow Logs are configured in the account that owns the Transit Gateway (typically the networking account). Since all cross-VPC traffic in a hub-and-spoke architecture traverses the Transit Gateway, these logs provide organization-wide cross-VPC visibility from a single configuration point. This is significantly simpler than ensuring every workload account has VPC Flow Logs enabled and properly delivered.
+
+However, Transit Gateway Flow Logs only capture traffic that *crosses* the Transit Gateway. Traffic within a single VPC (subnet-to-subnet, ENI-to-ENI) is not visible. You still need VPC Flow Logs for intra-VPC visibility.
+
+## Documentation
+
+<div class="grid cards" markdown>
+
+*   :material-file-document: **VPC Flow Logs documentation**
+
+    ---
+
+    Complete guide to Flow Log configuration, custom log format fields, delivery destinations, and IAM permissions.
+
+    [:octicons-arrow-right-24: Documentation](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html)
+
+*   :material-file-document: **Transit Gateway Flow Logs**
+
+    ---
+
+    Configuration and field reference for Transit Gateway Flow Logs, including cross-account delivery.
+
+    [:octicons-arrow-right-24: Documentation](https://docs.aws.amazon.com/vpc/latest/tgw/tgw-flow-logs.html)
+
+*   :material-database-search: **Querying Flow Logs with Athena**
+
+    ---
+
+    Pre-built Athena table definitions, partition projection setup, and example queries for Flow Log analysis.
+
+    [:octicons-arrow-right-24: Athena integration](https://docs.aws.amazon.com/athena/latest/ug/vpc-flow-logs.html)
+
+*   :material-swap-horizontal: **VPC Lattice access logs**
+
+    ---
+
+    Access log configuration, field reference, and delivery options for VPC Lattice service networks.
+
+    [:octicons-arrow-right-24: Documentation](https://docs.aws.amazon.com/vpc-lattice/latest/ug/monitoring-access-logs.html)
+
+*   :material-shield-check: **Network Firewall logging**
+
+    ---
+
+    Alert and flow log configuration, log types, and integration with S3 and CloudWatch Logs.
+
+    [:octicons-arrow-right-24: Documentation](https://docs.aws.amazon.com/network-firewall/latest/developerguide/firewall-logging.html)
+
+*   :material-currency-usd: **VPC Flow Logs pricing**
+
+    ---
+
+    Detailed pricing for Flow Log ingestion by destination (S3, CloudWatch Logs, Kinesis Data Firehose) with volume tiers.
+
+    [:octicons-arrow-right-24: Pricing](https://aws.amazon.com/cloudwatch/pricing/)
+
+</div>
+
+## Related Observability Pages
+
+- **[External Traffic Monitoring](external-traffic.md)** — Covers visibility into traffic between your AWS resources and the internet, including NAT Gateway logs, ALB access logs, and CloudFront logs.
+- **[AWS Services Monitoring](service-monitoring.md)** — Covers health and performance monitoring of the networking services themselves (Transit Gateway metrics, NAT Gateway CloudWatch metrics, VPC endpoint metrics).
+- **[Notifications](notifications.md)** — Covers alerting and notification patterns built on top of the monitoring data described here.
+
+**Relationship to Foundation:**
+
+- **[Amazon VPC](../foundation/vpc.md)**: VPC Flow Logs are configured at the VPC level. VPC design (CIDR, subnets, route tables) determines what traffic patterns are visible and how to interpret them.
+- **[Subnets](../foundation/subnets.md)**: Subnet IDs in Flow Logs identify which tier (public, private, data) traffic originates from — essential for security analysis.
+
+**Relationship to Connectivity:**
+
+- **[Connectivity Within AWS](../connectivity/within-aws.md)**: Transit Gateway Flow Logs provide visibility into the traffic that Transit Gateway and Cloud WAN route between VPCs. The `traffic-path` field in VPC Flow Logs identifies which connectivity service a flow used.

--- a/content/observability/notifications.md
+++ b/content/observability/notifications.md
@@ -1,3 +1,309 @@
 # Notifications
 
-Content coming soon.
+!!! info "Prerequisites"
+    This section assumes familiarity with [AWS Services Monitoring](service-monitoring.md) and [AWS Organizations](../foundation/organizations.md). Review those topics first if you're new to AWS networking observability and multi-account governance.
+
+The best monitoring in the world is worthless if nobody sees the alert. Notifications bridge the gap between detecting a problem and getting the right person to act on it. For networking specifically, the stakes are high: a VPN tunnel down, a Direct Connect BGP session flap, or a Network Firewall dropping traffic affects every workload that depends on that path. The difference between a five-minute blip and a two-hour outage is almost always how fast the notification reaches someone who can respond.
+
+This page covers the notification pipeline end-to-end: from the metric or event that signals a problem, through the alarm or rule that decides it matters, to the delivery mechanism that reaches the right team at the right time. The organizing principle is **signal over noise** — the number one operational failure in monitoring is alert fatigue, where teams ignore alerts because too many of them are false positives or low-priority noise.
+
+Notifications in a multi-account AWS environment require deliberate architecture. Events originate in workload accounts, but the networking team typically operates from a centralized monitoring account. Cross-account event forwarding, centralized alarm aggregation, and Organization-wide health event visibility are not optional extras — they are the baseline for any production network.
+
+``` mermaid
+graph LR
+    subgraph Sources["Event Sources"]
+        CW["CloudWatch Metrics<br/>Threshold & anomaly"]
+        EB["EventBridge Events<br/>State changes"]
+        Health["AWS Health<br/>Service events"]
+    end
+
+    subgraph Decision["Alarm & Rule Layer"]
+        Alarm["CloudWatch Alarms<br/>Simple & composite"]
+        Rule["EventBridge Rules<br/>Pattern matching"]
+    end
+
+    subgraph Routing["Delivery & Routing"]
+        SNS["Amazon SNS<br/>Fan-out"]
+        Chatbot["AWS Chatbot<br/>Slack & Teams"]
+    end
+
+    subgraph Destinations["Destinations"]
+        Email["Email"]
+        Slack["Slack / Teams"]
+        PD["PagerDuty / Opsgenie"]
+        Lambda["Lambda<br/>Auto-remediation"]
+        SQS["SQS<br/>Ticket creation"]
+    end
+
+    CW --> Alarm
+    EB --> Rule
+    Health --> Rule
+    Alarm --> SNS
+    Rule --> SNS
+    Alarm --> Chatbot
+    Rule --> Chatbot
+    SNS --> Email
+    SNS --> PD
+    SNS --> Lambda
+    SNS --> SQS
+    Chatbot --> Slack
+
+    style Sources fill:none,stroke:#2563eb,stroke-width:2px,stroke-dasharray:5 5,color:#2563eb
+    style Decision fill:none,stroke:#7c3aed,stroke-width:2px,stroke-dasharray:5 5,color:#7c3aed
+    style Routing fill:none,stroke:#059669,stroke-width:2px,stroke-dasharray:5 5,color:#059669
+    style Destinations fill:none,stroke:#ff9900,stroke-width:2px,stroke-dasharray:5 5,color:#ff9900
+    style CW fill:#2563eb,stroke:#1e40af,color:#fff
+    style EB fill:#2563eb,stroke:#1e40af,color:#fff
+    style Health fill:#2563eb,stroke:#1e40af,color:#fff
+    style Alarm fill:#7c3aed,stroke:#6d28d9,color:#fff
+    style Rule fill:#7c3aed,stroke:#6d28d9,color:#fff
+    style SNS fill:#059669,stroke:#047857,color:#fff
+    style Chatbot fill:#059669,stroke:#047857,color:#fff
+    style Email fill:#ff9900,stroke:#c27400,color:#fff
+    style Slack fill:#ff9900,stroke:#c27400,color:#fff
+    style PD fill:#ff9900,stroke:#c27400,color:#fff
+    style Lambda fill:#ff9900,stroke:#c27400,color:#fff
+    style SQS fill:#ff9900,stroke:#c27400,color:#fff
+```
+
+## Key Capabilities
+
+<div class="grid cards" markdown>
+
+*   :material-bell-alert: **CloudWatch Alarms**
+
+    ---
+
+    Metric-based alerting with static thresholds, anomaly detection bands, and math expressions. Composite alarms combine multiple alarm states into a single actionable signal, reducing noise from transient single-metric spikes.
+
+*   :material-lightning-bolt: **Amazon EventBridge**
+
+    ---
+
+    Event-driven notifications for state changes: VPN tunnel up/down, Direct Connect connection state, Network Firewall alert, BGP session flap. Pattern-matching rules route events to any target without polling.
+
+*   :material-email-fast: **Amazon SNS**
+
+    ---
+
+    Fan-out delivery to email, SMS, HTTPS endpoints (PagerDuty, Opsgenie), Lambda functions, and SQS queues. SNS is the universal glue between alarm sources and notification destinations.
+
+*   :material-heart-pulse: **AWS Health Dashboard & API**
+
+    ---
+
+    Proactive awareness of AWS service events affecting your resources: scheduled maintenance on Direct Connect, degraded performance in a Region, or planned VPN endpoint rotation. Organization-wide Health events aggregate across all member accounts.
+
+*   :material-chat: **AWS Chatbot**
+
+    ---
+
+    Delivers CloudWatch alarms and EventBridge notifications directly to Slack channels and Microsoft Teams. Interactive — teams can acknowledge, snooze, or run runbooks from the chat interface.
+
+*   :material-set-merge: **Composite Alarms**
+
+    ---
+
+    Combine multiple alarms into a single parent alarm that only fires when a combination of conditions confirms a real problem. The primary tool for eliminating alert fatigue in complex network topologies.
+
+</div>
+
+## Best Practices
+
+### Alarm Design
+
+#### Alarm on what matters, not on everything
+
+Every alarm that fires without requiring action trains your team to ignore alarms. Before creating an alarm, answer: "If this fires at 3 AM, what will someone do?" If the answer is "look at it tomorrow," it's not a P1 alarm — it's a dashboard metric or a daily report item.
+
+For networking, the alarms that matter are the ones that indicate traffic is affected or about to be affected: tunnel down, BGP session lost, NAT Gateway ErrorPortAllocation spiking, Network Firewall dropping legitimate traffic, Transit Gateway blackholing packets. Metrics like "VPN tunnel bytes in" are useful for dashboards but rarely warrant an alarm unless they drop to zero (which means the tunnel is effectively dead even if the state shows "UP").
+
+***Key insight:*** *If your team routinely ignores alarms, you don't have a monitoring problem — you have an alarm design problem. Every alarm must have a clear owner and a defined response action.*
+
+#### Use anomaly detection for metrics without obvious thresholds
+
+Some networking metrics don't have a natural static threshold. What's "normal" for Transit Gateway bytes processed depends on time of day, day of week, and business seasonality. CloudWatch anomaly detection builds a model of expected behavior and alarms when the metric deviates beyond a configurable band width. This is particularly useful for detecting DDoS traffic patterns, unexpected traffic shifts after a routing change, or gradual degradation that wouldn't trip a static threshold.
+
+#### Implement severity tiers with distinct routing
+
+Not every problem deserves a page. Define clear severity tiers and route each tier differently:
+
+| Severity | Criteria | Routing | Response time |
+| --- | --- | --- | --- |
+| **P1 — Critical** | Traffic is dropping, connectivity is lost, failover has not occurred | PagerDuty/Opsgenie page, Slack war-room channel | Immediate (< 5 min) |
+| **P2 — High** | Redundancy is degraded, single path remaining, capacity approaching limits | Slack notification, email to on-call | Business hours (< 4 hr) |
+| **P3 — Informational** | Planned maintenance, minor metric deviation, successful failover | Slack channel, daily digest email | Next business day |
+
+Map each CloudWatch alarm and EventBridge rule to exactly one severity tier. If you can't decide the tier, the alarm probably needs to be split into two: one for the critical condition and one for the informational condition.
+
+### Composite Alarms
+
+#### Use composite alarms to confirm real problems before paging
+
+A single metric crossing a threshold is often not a problem. A VPN tunnel briefly flapping during AWS-side maintenance is expected. But if *both* tunnels on a connection are down simultaneously, that's a real outage. Composite alarms let you express this logic: "alarm only when Alarm A AND Alarm B are both in ALARM state."
+
+Networking patterns that benefit from composite alarms:
+
+- **Both VPN tunnels down** on the same connection (single tunnel down is P2; both down is P1)
+- **NAT Gateway errors AND increased packet drops** (errors alone might be transient; combined with drops confirms impact)
+- **BGP session down AND no traffic on the backup path** (BGP down alone might mean traffic shifted to backup successfully)
+- **Multiple Transit Gateway attachments unhealthy** (one attachment flapping is isolated; multiple suggests a broader issue)
+
+#### Suppress child alarm actions when using composite alarms
+
+When you create a composite alarm, configure the child alarms with `ActionsEnabled: false` for their notification actions. Let only the composite alarm trigger notifications. This prevents duplicate alerts (one from each child plus one from the composite) and ensures the team receives a single, contextualized notification that describes the combined condition rather than three separate alerts they have to mentally correlate.
+
+### EventBridge for State Changes
+
+#### Use EventBridge rules for infrastructure state-change notifications
+
+CloudWatch Alarms are metric-based. EventBridge handles *events* — discrete state changes that don't map cleanly to a metric threshold. For networking, the most important EventBridge patterns are:
+
+- **VPN tunnel state change**: `source: aws.vpn`, `detail-type: "VPN Tunnel Status Change"`
+- **Direct Connect connection state change**: `source: aws.directconnect`, `detail-type: "Direct Connect Connection State Change"`
+- **Direct Connect virtual interface state change**: BGP session up/down events
+- **Network Firewall alert**: Stateful rule match events forwarded to EventBridge
+- **Transit Gateway attachment state change**: Attachment available/failing/deleting
+- **AWS Health events**: Scheduled maintenance, service issues affecting your resources
+
+EventBridge rules match on event patterns and route to targets (SNS, Lambda, SQS, Step Functions). This is the right mechanism for "something changed state" notifications, as opposed to "a metric crossed a threshold."
+
+#### Forward events cross-account to a centralized monitoring account
+
+In a multi-account environment, networking events originate in the account that owns the resource (the centralized networking account for Transit Gateway and Direct Connect, workload accounts for VPC-level events). Configure [EventBridge cross-account event forwarding](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-cross-account.html) to send networking events to a centralized monitoring account where your notification rules, SNS topics, and Chatbot configurations live.
+
+This pattern avoids duplicating notification infrastructure in every account and gives the networking team a single pane of glass for all network events across the Organization. Use an Organization-level EventBridge rule on the default event bus in each account to forward events matching networking patterns to the monitoring account's event bus.
+
+***Key insight:*** *Centralize notification logic, not event generation. Events should originate where resources live, but routing decisions and delivery configuration belong in one place.*
+
+### AWS Health Events
+
+#### Subscribe to Organization-wide Health events for proactive awareness
+
+AWS Health events tell you about scheduled maintenance (Direct Connect circuit maintenance windows, VPN endpoint rotation), service issues (degraded networking in a Region), and account-specific notifications. With [AWS Organizations Health](https://docs.aws.amazon.com/health/latest/ug/aggregate-events.html), you see events across all member accounts from the management account or a delegated administrator.
+
+Create EventBridge rules that match Health events for networking services (`directconnect`, `vpn`, `ec2`, `networkfirewall`, `transitgateway`) and route them to the networking team's Slack channel. Knowing about a scheduled Direct Connect maintenance window 14 days in advance lets you validate failover paths *before* the maintenance occurs, rather than discovering at 2 AM that your backup path doesn't work.
+
+### Notification Routing
+
+#### Route alarms to the team that owns the response, not to everyone
+
+A common anti-pattern is a single SNS topic that sends every network alarm to every engineer. This guarantees alert fatigue. Instead, create separate SNS topics per team and per severity:
+
+- `networking-p1-critical` → PagerDuty rotation for the networking team
+- `networking-p2-high` → Slack #network-ops channel
+- `networking-p3-info` → Slack #network-notifications channel (muted by default)
+- `workload-team-a-network` → Team A's own channel for alarms on their VPC resources
+
+Application teams should receive notifications about *their* workload's network health (their VPC endpoints, their load balancer health), not about shared infrastructure they can't act on. The networking team receives notifications about shared infrastructure (Transit Gateway, Direct Connect, Network Firewall).
+
+### Automated Remediation
+
+#### Use EventBridge → Lambda for automated response to known failure modes
+
+Some network events have well-defined, safe automated responses:
+
+- **VPN tunnel down** → Lambda triggers a CloudFormation stack update to rotate pre-shared keys and re-establish the tunnel
+- **NAT Gateway ErrorPortAllocation** → Lambda provisions an additional NAT Gateway and updates route tables
+- **Direct Connect connection down** → Lambda verifies backup VPN path is active and creates a ticket if it isn't
+- **Network Firewall rule group update failed** → Lambda rolls back to the previous rule group version
+
+Automated remediation is not a replacement for human response — it's a first responder that buys time. The Lambda should always create a ticket or send a notification *in addition to* taking the remediation action, so the team knows what happened and can verify the fix.
+
+***Key insight:*** *Automate the response to events you've seen three or more times. If you've manually remediated the same failure mode three times, the fourth time should be automated.*
+
+### Cost Awareness
+
+#### Understand notification costs at scale
+
+Individual notification costs are negligible, but they compound in large Organizations:
+
+| Component | Cost | Scale consideration |
+| --- | --- | --- |
+| CloudWatch Alarm | ~$0.10/alarm/month (standard), ~$0.30/alarm/month (anomaly detection) | 100 alarms across 50 accounts = $500-1,500/month |
+| EventBridge rule | $1.00 per million events matched | Typically negligible for networking events |
+| SNS notification | $0.50 per million email deliveries, $0.75 per 100 SMS | Email is essentially free; SMS adds up for large on-call rotations |
+| AWS Chatbot | No additional charge | Free delivery to Slack/Teams |
+
+The real cost risk is not the notification services themselves — it's creating hundreds of alarms that nobody looks at. Each unused alarm costs money and, worse, dilutes the signal from alarms that matter. Audit your alarms quarterly: if an alarm hasn't fired in 6 months, either the threshold is wrong or the alarm isn't needed.
+
+## Combining notifications with other services
+
+| Combination | Notifications provide | Other service provides |
+| --- | --- | --- |
+| **CloudWatch Alarms + CloudWatch Metrics** | Threshold evaluation, state management, notification triggering | The underlying metric data from networking services (VPN, Direct Connect, NAT Gateway, Transit Gateway) |
+| **EventBridge + AWS Health** | Rule matching and routing to notification targets | Proactive service event information (maintenance, degradation, advisories) |
+| **SNS + PagerDuty/Opsgenie** | Fan-out delivery to HTTPS endpoints | On-call rotation, escalation policies, incident management workflow |
+| **AWS Chatbot + Slack/Teams** | Formatted alarm delivery with interactive actions | Team communication, acknowledgment, runbook execution from chat |
+| **EventBridge + Lambda** | Event routing to compute targets | Automated remediation logic (failover, scaling, ticket creation) |
+| **CloudWatch + AWS Organizations** | Cross-account alarm aggregation in a centralized monitoring account | Account structure, delegated administration, Organization-wide Health events |
+| **Composite Alarms + Simple Alarms** | Noise reduction through boolean logic on alarm states | Individual metric evaluation per resource or per condition |
+
+## Documentation
+
+<div class="grid cards" markdown>
+
+*   :material-file-document: **Amazon CloudWatch Alarms**
+
+    ---
+
+    Complete documentation for creating metric alarms, anomaly detection alarms, composite alarms, and configuring alarm actions.
+
+    [:octicons-arrow-right-24: Documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html)
+
+*   :material-file-document: **Amazon EventBridge User Guide**
+
+    ---
+
+    Event patterns, rules, targets, cross-account event delivery, and integration with AWS services.
+
+    [:octicons-arrow-right-24: Documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is.html)
+
+*   :material-file-document: **Amazon SNS Developer Guide**
+
+    ---
+
+    Topic creation, subscription management, message filtering, and delivery to email, SMS, HTTPS, Lambda, and SQS.
+
+    [:octicons-arrow-right-24: Documentation](https://docs.aws.amazon.com/sns/latest/dg/welcome.html)
+
+*   :material-file-document: **AWS Health User Guide**
+
+    ---
+
+    Organization-wide health events, EventBridge integration, and programmatic access via the Health API.
+
+    [:octicons-arrow-right-24: Documentation](https://docs.aws.amazon.com/health/latest/ug/what-is-aws-health.html)
+
+*   :material-chat: **AWS Chatbot Administrator Guide**
+
+    ---
+
+    Configuring Slack and Microsoft Teams integrations, channel permissions, and interactive alarm management.
+
+    [:octicons-arrow-right-24: Documentation](https://docs.aws.amazon.com/chatbot/latest/adminguide/what-is.html)
+
+*   :material-currency-usd: **CloudWatch Pricing**
+
+    ---
+
+    Alarm pricing tiers (standard, high-resolution, anomaly detection, composite), metric costs, and free tier details.
+
+    [:octicons-arrow-right-24: Pricing](https://aws.amazon.com/cloudwatch/pricing/)
+
+</div>
+
+## Related Observability Pages
+
+- **[AWS Services Monitoring](service-monitoring.md)** — The metrics and health checks that feed into the notification pipeline covered on this page
+- **[Internal Traffic Monitoring](internal-traffic.md)** — Flow logs and traffic mirroring that provide the raw data for anomaly-based network alarms
+- **[External Traffic Monitoring](external-traffic.md)** — Internet-facing traffic visibility that drives DDoS and abuse notifications
+
+**Relationship to Foundation:**
+
+- **[AWS Organizations](../foundation/organizations.md)** — Organization structure determines cross-account event forwarding topology and centralized monitoring account placement
+
+**Relationship to Connectivity:**
+
+- **[Hybrid & Multi-Cloud](../connectivity/hybrid-multicloud.md)** — Direct Connect and VPN state-change events are the most critical networking notifications to configure
+- **[Connectivity Within AWS](../connectivity/within-aws.md)** — Transit Gateway and Cloud WAN attachment health drives composite alarm design

--- a/content/observability/service-monitoring.md
+++ b/content/observability/service-monitoring.md
@@ -1,3 +1,380 @@
 # AWS Services Monitoring
 
-Content coming soon.
+!!! info "Prerequisites"
+    This section assumes familiarity with [Connectivity Within AWS](../connectivity/within-aws.md), [Load Balancing](../application-networking/load-balancing.md), and [Hybrid & Multi-Cloud](../connectivity/hybrid-multicloud.md). Review those topics first if you're new to AWS networking fundamentals.
+
+Monitoring network traffic (covered in [Internal Traffic](internal-traffic.md) and [External Traffic](external-traffic.md)) tells you what's flowing through your network. Monitoring the networking *services themselves* tells you whether the infrastructure carrying that traffic is healthy. A Transit Gateway with blackhole drops, a NAT Gateway exhausting its port allocation, or a Direct Connect connection flapping between states — these are service-level failures that traffic monitoring alone won't catch until users are already affected.
+
+This page focuses on the operational health of AWS networking services: the CloudWatch metrics that matter, the alarms you should configure from day one, and the automation patterns that turn monitoring signals into remediation actions. The goal is to detect degradation in the networking plane before it becomes an outage, and to respond automatically where possible.
+
+Service monitoring in a multi-account AWS environment requires a deliberate architecture. Metrics live in the account that owns the resource, but the networking team needs a unified view across all accounts and Regions. The patterns here assume a centralized monitoring account with cross-account CloudWatch dashboards and a shared EventBridge bus for networking events.
+
+``` mermaid
+graph TB
+    subgraph Sources["Networking Service Metrics"]
+        TGW["Transit Gateway"]
+        NAT["NAT Gateway"]
+        DX["Direct Connect"]
+        VPN["Site-to-Site VPN"]
+        ALB["Application LB"]
+        NLB["Network LB"]
+        NFW["Network Firewall"]
+        R53["Route 53 Resolver"]
+        Lattice["VPC Lattice"]
+    end
+
+    subgraph Monitoring["Centralized Monitoring Account"]
+        CW["CloudWatch Metrics<br/>Cross-account observability"]
+        Alarms["CloudWatch Alarms<br/>Composite & anomaly detection"]
+        Dash["CloudWatch Dashboards<br/>Cross-account, cross-Region"]
+    end
+
+    subgraph Action["Automated Response"]
+        EB["EventBridge Rules"]
+        SNS["SNS Notifications"]
+        Lambda["Lambda Remediation"]
+        Incident["Incident Manager"]
+    end
+
+    Sources --> CW
+    CW --> Alarms
+    CW --> Dash
+    Alarms --> EB
+    EB --> SNS
+    EB --> Lambda
+    EB --> Incident
+
+    style Sources fill:none,stroke:#2563eb,stroke-width:2px,stroke-dasharray:5 5,color:#2563eb
+    style Monitoring fill:none,stroke:#7c3aed,stroke-width:2px,stroke-dasharray:5 5,color:#7c3aed
+    style Action fill:none,stroke:#059669,stroke-width:2px,stroke-dasharray:5 5,color:#059669
+    style TGW fill:#2563eb,stroke:#1e40af,color:#fff
+    style NAT fill:#2563eb,stroke:#1e40af,color:#fff
+    style DX fill:#2563eb,stroke:#1e40af,color:#fff
+    style VPN fill:#2563eb,stroke:#1e40af,color:#fff
+    style ALB fill:#2563eb,stroke:#1e40af,color:#fff
+    style NLB fill:#2563eb,stroke:#1e40af,color:#fff
+    style NFW fill:#2563eb,stroke:#1e40af,color:#fff
+    style R53 fill:#2563eb,stroke:#1e40af,color:#fff
+    style Lattice fill:#2563eb,stroke:#1e40af,color:#fff
+    style CW fill:#7c3aed,stroke:#6d28d9,color:#fff
+    style Alarms fill:#7c3aed,stroke:#6d28d9,color:#fff
+    style Dash fill:#7c3aed,stroke:#6d28d9,color:#fff
+    style EB fill:#059669,stroke:#047857,color:#fff
+    style SNS fill:#059669,stroke:#047857,color:#fff
+    style Lambda fill:#059669,stroke:#047857,color:#fff
+    style Incident fill:#059669,stroke:#047857,color:#fff
+```
+
+## Critical metrics by service
+
+Not all CloudWatch metrics deserve an alarm. The table below identifies the metrics that signal real operational problems — the ones you should alarm on from day one, before the first production workload routes through the service.
+
+### Transit Gateway
+
+| Metric | Why it matters | Alarm condition |
+| --- | --- | --- |
+| `PacketDropCountBlackhole` | Traffic is being sent to a route that leads nowhere. Indicates a missing or misconfigured route table entry. | > 0 for 2 consecutive periods |
+| `PacketDropCountNoRoute` | No matching route exists for the destination. Often caused by missing route propagation or a detached attachment. | > 0 for 2 consecutive periods |
+| `BytesIn` / `BytesOut` | Baseline throughput. Sudden drops indicate connectivity loss; sustained growth signals capacity planning needs. | Anomaly detection band (2 standard deviations) |
+| `AttachmentCount` | Track attachment growth against the per-Region quota (default 5,000). | > 80% of quota |
+
+### NAT Gateway
+
+| Metric | Why it matters | Alarm condition |
+| --- | --- | --- |
+| `ErrorPortAllocation` | The NAT Gateway has exhausted its 55,000 simultaneous connections to a single destination. Workloads will fail to establish new connections. | > 0 for 1 period |
+| `PacketsDropCount` | Packets dropped due to NAT Gateway processing limits. Indicates the gateway is overwhelmed. | > 0 sustained over 3 periods |
+| `ActiveConnectionCount` | Tracks connection table utilization. Useful for capacity planning and detecting connection leaks. | Anomaly detection or > 80% of expected baseline |
+| `BytesOutToDestination` | Data processing volume directly correlates with cost. Unexpected spikes indicate misconfigured routing or data exfiltration. | Anomaly detection band |
+| `ConnectionEstablishedCount` | Rate of new connections. Sudden spikes may indicate scanning or misconfigured retry logic. | Anomaly detection band |
+
+***Key insight:*** *`ErrorPortAllocation` is the single most critical NAT Gateway metric. When it fires, connections are already failing. Alarm on it immediately and consider multiple NAT Gateways or destination diversification.*
+
+### Direct Connect
+
+| Metric | Why it matters | Alarm condition |
+| --- | --- | --- |
+| `ConnectionState` | Binary: the physical connection is up or down. State changes indicate fiber cuts, router failures, or maintenance events. | State != 1 (up) for 1 period |
+| `VirtualInterfaceBpsEgress` / `VirtualInterfaceBpsIngress` | Per-VIF throughput. Approaching the port capacity means you need to add capacity or shift traffic. | > 80% of port speed sustained over 5 minutes |
+| `ConnectionBpsEgress` / `ConnectionBpsIngress` | Aggregate connection throughput. | > 80% of port speed sustained over 5 minutes |
+| `ConnectionLightLevelTx` / `ConnectionLightLevelRx` | Optical signal strength. Degrading light levels predict physical failures before they happen. | Outside acceptable dBm range for the optic type |
+
+### Site-to-Site VPN
+
+| Metric | Why it matters | Alarm condition |
+| --- | --- | --- |
+| `TunnelState` | Binary: the IPsec tunnel is up or down. Each VPN connection has two tunnels for redundancy. | Either tunnel state = 0 for 2 consecutive periods |
+| `TunnelDataIn` / `TunnelDataOut` | Per-tunnel throughput. Asymmetric traffic may indicate a routing problem or a failed tunnel with traffic on the remaining one. | Anomaly detection; alert on zero traffic when traffic is expected |
+
+***Key insight:*** *Alarm when a single tunnel goes down, not just when both are down. A single-tunnel failure means you're running without redundancy — the next failure is an outage.*
+
+### Application Load Balancer
+
+| Metric | Why it matters | Alarm condition |
+| --- | --- | --- |
+| `HealthyHostCount` | Tracks how many targets are passing health checks. A declining count means capacity is shrinking. | < expected minimum per target group |
+| `UnHealthyHostCount` | Targets failing health checks. Non-zero means something is wrong with the application or its dependencies. | > 0 sustained over 2 periods |
+| `HTTPCode_ELB_5XX_Count` | Errors generated by the ALB itself (not the targets). Indicates ALB-level issues like capacity exhaustion or no healthy targets. | > 0 sustained over 3 periods |
+| `TargetResponseTime` | P99 latency from the ALB to targets. Degradation here affects every request. | Anomaly detection or > SLA threshold |
+| `RejectedConnectionCount` | Connections rejected because the ALB hit its maximum connections. Indicates undersized subnets or a traffic spike beyond ALB scaling. | > 0 for 1 period |
+| `RequestCount` | Baseline traffic volume. Useful for anomaly detection and correlating with other metrics. | Anomaly detection band |
+
+### Network Load Balancer
+
+| Metric | Why it matters | Alarm condition |
+| --- | --- | --- |
+| `HealthyHostCount` / `UnHealthyHostCount` | Same as ALB — tracks target availability. | Same thresholds as ALB |
+| `TCP_ELB_Reset_Count` | TCP resets generated by the NLB (not targets). Indicates idle timeout mismatches or connection tracking issues. | Anomaly detection; sustained increase |
+| `ProcessedBytes` | Total throughput. Correlates directly with cost and capacity utilization. | Anomaly detection band |
+| `NewFlowCount` | Rate of new TCP/UDP flows. Sudden spikes may indicate DDoS or misconfigured clients. | Anomaly detection band |
+| `UnHealthyHostCount` (per AZ) | Per-AZ health. Critical when cross-zone load balancing is off (NLB default). | > 0 in any single AZ |
+
+### AWS Network Firewall
+
+| Metric | Why it matters | Alarm condition |
+| --- | --- | --- |
+| `DroppedPackets` | Packets explicitly dropped by firewall rules. Expected in normal operation, but sudden spikes indicate either an attack or a rule misconfiguration blocking legitimate traffic. | Anomaly detection band |
+| `PassedPackets` | Packets allowed through. A sudden drop to zero means traffic isn't reaching the firewall (routing issue) or the firewall is down. | < baseline for 2 periods |
+| `ReceivedPackets` | Total packets entering the firewall. Baseline for capacity planning. | Anomaly detection band |
+| `Packets` (per rule group) | Per-rule-group hit counts. Identifies which rules are active and whether new rules are matching as expected. | Monitor for zero hits on rules expected to match |
+
+### Route 53 Resolver
+
+| Metric | Why it matters | Alarm condition |
+| --- | --- | --- |
+| `InboundQueryVolume` | DNS queries arriving from on-premises or peered networks. Spikes may indicate DNS amplification or misconfigured resolvers. | Anomaly detection band |
+| `OutboundQueryVolume` | DNS queries forwarded to on-premises or external resolvers. Drops indicate forwarding rule issues. | < baseline for 3 periods |
+| `FirewallRuleGroupQueryVolume` | Queries evaluated by DNS Firewall rules. Tracks DNS-layer security enforcement. | Monitor for expected baseline |
+
+### VPC Lattice
+
+| Metric | Why it matters | Alarm condition |
+| --- | --- | --- |
+| `RequestCount` | Total requests through the service network. Baseline for capacity and cost tracking. | Anomaly detection band |
+| `HTTPCode_Target_4XX_Count` | Client errors at the target. Elevated counts indicate API contract issues or auth failures. | Anomaly detection band |
+| `HTTPCode_Target_5XX_Count` | Server errors at the target. Direct indicator of backend health problems. | > threshold for 2 periods |
+| `TargetResponseTime` | Latency from VPC Lattice to the target. Degradation affects all consumers on the service network. | > SLA threshold or anomaly detection |
+
+## Best Practices
+
+### Alarm design
+
+#### Alarm on state changes, not just thresholds
+
+Many networking services have binary state metrics (tunnel up/down, connection active/inactive, BGP session established/idle). These deserve state-change alarms, not threshold-based alarms. A VPN tunnel transitioning from up to down is immediately actionable regardless of traffic volume. Configure alarms that trigger on the state value itself (e.g., `TunnelState < 1` for 1 evaluation period) rather than waiting for traffic metrics to reflect the failure.
+
+For Direct Connect, monitor `ConnectionState` transitions. For VPN, monitor individual `TunnelState` per tunnel. For ALB/NLB, monitor `HealthyHostCount` dropping below the expected minimum rather than waiting for error rates to climb.
+
+#### Use composite alarms to reduce noise
+
+Individual metric alarms generate noise. A brief spike in `PacketDropCountNoRoute` during a Transit Gateway route table update is expected. A sustained spike combined with increased `ErrorPortAllocation` on a NAT Gateway in the same path is a real problem.
+
+[Composite alarms](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Composite_Alarm.html) combine multiple alarm states with AND/OR logic. Configure them to alert only when multiple signals confirm a problem:
+
+- Transit Gateway: `PacketDropCountBlackhole > 0` AND `BytesOut` anomaly (confirms traffic is affected, not just a transient routing update)
+- NAT Gateway: `ErrorPortAllocation > 0` AND `ActiveConnectionCount` above baseline (confirms the port exhaustion is real load, not a monitoring artifact)
+- Load Balancer: `UnHealthyHostCount > 0` AND `HealthyHostCount < minimum` (confirms actual capacity loss, not a single target cycling)
+
+***Key insight:*** *Composite alarms are the difference between a monitoring system that gets ignored and one that gets acted on. Every alert that fires without requiring action trains your team to ignore alerts.*
+
+#### Use anomaly detection instead of static thresholds
+
+Static thresholds require constant tuning as traffic patterns change. CloudWatch [anomaly detection](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Anomaly_Detection.html) builds a model of expected behavior and alerts when metrics deviate from the learned pattern. This is particularly effective for:
+
+- `BytesIn`/`BytesOut` on Transit Gateway and NAT Gateway (traffic follows daily/weekly patterns)
+- `RequestCount` on ALB and VPC Lattice (application traffic has predictable cycles)
+- `NewFlowCount` on NLB (connection rates correlate with business activity)
+
+Anomaly detection costs the same as a standard alarm but adapts automatically to traffic growth, seasonal patterns, and baseline shifts. Use a band width of 2 standard deviations for most networking metrics — tight enough to catch real anomalies, loose enough to avoid false positives during normal variance.
+
+#### Monitor quotas before you hit them
+
+Every networking service has quotas. Hitting a quota silently — no new VPN connections, no additional Transit Gateway attachments, no more NAT Gateway elastic IPs — causes failures that look like service issues but are actually capacity limits.
+
+Use [AWS Service Quotas](https://docs.aws.amazon.com/servicequotas/latest/userguide/intro.html) integration with CloudWatch to alarm at 80% utilization:
+
+| Service | Quota to monitor | Default limit |
+| --- | --- | --- |
+| Transit Gateway | Attachments per TGW | 5,000 |
+| Transit Gateway | Routes per route table | 10,000 |
+| NAT Gateway | NAT Gateways per AZ | 5 |
+| VPN | VPN connections per VGW/TGW | 10 / 20 |
+| Direct Connect | Virtual interfaces per connection | 50 |
+| ALB | Rules per ALB | 100 |
+| NLB | Targets per target group | 500 (IP) / 500 (instance) |
+| Network Firewall | Rule groups per firewall policy | 20 |
+
+### Multi-account monitoring architecture
+
+#### Deploy a centralized monitoring account
+
+In a multi-account environment, networking resources are distributed across shared-services accounts, workload accounts, and connectivity accounts. The networking team needs a single pane of glass.
+
+Use [CloudWatch cross-account observability](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html) to designate a monitoring account that can view metrics, logs, and traces from all source accounts. Configure this at the AWS Organizations level so new accounts are automatically enrolled.
+
+The monitoring account hosts:
+- Cross-account dashboards showing all networking service health
+- Centralized alarms that evaluate metrics from any source account
+- EventBridge rules that aggregate networking events from all accounts
+
+#### Build cross-Region dashboards for the networking team
+
+A single CloudWatch dashboard can display metrics from multiple Regions. Build dashboards organized by service type, not by account or Region:
+
+- **Transit Gateway dashboard**: all TGW metrics across all Regions, with per-attachment drill-down
+- **Hybrid connectivity dashboard**: all Direct Connect and VPN metrics, showing connection state and utilization
+- **Load balancer dashboard**: ALB and NLB health across all workload accounts
+- **DNS dashboard**: Route 53 Resolver query volumes and DNS Firewall activity
+
+Each dashboard should show the last 3 hours by default with the ability to zoom to 1 week for trend analysis.
+
+***Key insight:*** *Organize dashboards by networking concern (connectivity health, capacity, security), not by AWS account or Region. The networking team thinks in terms of paths and services, not account boundaries.*
+
+### IPv6 monitoring considerations
+
+#### Monitor dual-stack metrics separately
+
+Several networking services report metrics that differ between IPv4 and IPv6 traffic paths. When running dual-stack:
+
+- **ALB/NLB**: Monitor `IPv6ProcessedBytes` and `IPv6RequestCount` separately from their IPv4 counterparts. A failure in the IPv6 path won't show up in aggregate metrics if IPv4 traffic dominates.
+- **NAT Gateway**: NAT64 metrics (`BytesOutToDestination` for IPv6-to-IPv4 translation) track a different failure mode than standard NAT. Monitor both paths.
+- **VPC Lattice**: Dual-stack service networks carry both IPv4 and IPv6 traffic. Monitor per-protocol error rates to catch IPv6-specific routing issues.
+
+#### Configure IPv6-specific health checks
+
+For services that support IPv6 health checks (ALB, NLB), configure health checks over both protocols when targets are dual-stack. An IPv4 health check passing doesn't guarantee the IPv6 path is functional — different security groups, NACLs, or routing may apply to each address family.
+
+### Cost-effective monitoring
+
+#### Use metric math to reduce alarm count
+
+CloudWatch charges per alarm per month. Instead of creating individual alarms for every NAT Gateway or every Transit Gateway attachment, use [metric math](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/using-metric-math.html) to aggregate:
+
+- Sum `ErrorPortAllocation` across all NAT Gateways in a Region into a single alarm
+- Calculate the ratio of `UnHealthyHostCount` to total targets across all target groups
+- Compute `PacketDropCountBlackhole + PacketDropCountNoRoute` as a single "routing failures" metric
+
+This reduces alarm count (and cost) while maintaining coverage. Create per-resource alarms only for the most critical individual resources (primary Direct Connect connections, production ALBs).
+
+#### Understand the cost model
+
+| CloudWatch component | Pricing consideration |
+| --- | --- |
+| Standard metrics | Free (included with the service) |
+| Custom metrics | $0.30/metric/month (first 10,000) |
+| Alarms (standard) | $0.10/alarm/month |
+| Alarms (high-resolution) | $0.30/alarm/month |
+| Anomaly detection alarms | $0.30/alarm/month |
+| Composite alarms | $0.50/alarm/month |
+| Dashboards | $3.00/dashboard/month (first 3 free) |
+| Cross-account observability | No additional charge for metrics |
+
+For a typical multi-account networking setup with 50 alarms, 5 dashboards, and 10 anomaly detection alarms, expect approximately $20–30/month in CloudWatch costs — negligible compared to the networking services themselves, but worth understanding to avoid surprise bills from over-instrumentation with custom metrics.
+
+#### Prefer built-in metrics over custom metrics
+
+Every networking service publishes metrics to CloudWatch at no additional cost. Before building custom metrics with Lambda functions or CloudWatch agents, verify the built-in metrics don't already cover your need. Custom metrics at $0.30/metric/month add up quickly when you're monitoring hundreds of resources across multiple accounts.
+
+### Automated remediation
+
+#### Use EventBridge for automated response
+
+CloudWatch alarms transition states. [EventBridge](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-what-is.html) captures those transitions and routes them to automated actions. Common networking remediation patterns:
+
+| Trigger | Automated action |
+| --- | --- |
+| VPN `TunnelState` → 0 on both tunnels | Trigger failover to backup VPN or Direct Connect path |
+| NAT Gateway `ErrorPortAllocation` > 0 | Scale out by provisioning additional NAT Gateways and updating route tables |
+| ALB `HealthyHostCount` < minimum | Trigger Auto Scaling step scaling or notify on-call |
+| Direct Connect `ConnectionState` → down | Update Route 53 health checks to failover to VPN backup |
+| Transit Gateway `PacketDropCountBlackhole` > 0 | Run diagnostic Lambda to identify the affected route and notify |
+| Network Firewall `DroppedPackets` spike | Capture packet samples and create incident ticket |
+
+#### Design health checks for networking services
+
+Beyond CloudWatch metrics, active health checking validates end-to-end path availability. Design synthetic checks that probe the networking layer:
+
+- **VPN path validation**: Lambda in the VPC sends ICMP or TCP probes through the VPN tunnel to an on-premises endpoint every 60 seconds. Failure triggers an alarm independent of the `TunnelState` metric (which only reflects IKE/IPsec state, not actual data-plane forwarding).
+- **NAT Gateway validation**: Lambda in a private subnet makes an HTTPS request to an external endpoint. Failure indicates NAT Gateway or internet gateway issues.
+- **Transit Gateway path validation**: Lambda in spoke VPC A sends a request to a known endpoint in spoke VPC B through the Transit Gateway. Validates routing, not just attachment state.
+- **Direct Connect path validation**: On-premises probe sends traffic to a known VPC endpoint. Validates the full path including BGP routing, not just the physical connection state.
+
+***Key insight:*** *CloudWatch metrics tell you the service is healthy. Synthetic health checks tell you the path works end-to-end. You need both — a healthy service with broken routing still means an outage.*
+
+## Combining service monitoring with other services
+
+| Combination | Service monitoring provides | Other service provides |
+| --- | --- | --- |
+| **Service monitoring + VPC Flow Logs** | Health state of networking services (up/down, error rates, capacity) | Actual traffic patterns, source/destination pairs, accepted/rejected flows |
+| **Service monitoring + AWS CloudTrail** | Runtime operational metrics | API-level audit trail (who changed what configuration and when) |
+| **Service monitoring + AWS Network Manager** | Per-service metric alarms and dashboards | Topology visualization and route analysis across the global network |
+| **Service monitoring + AWS Health Dashboard** | Your resource-specific metrics and alarms | AWS-side service events, maintenance notifications, and regional issues |
+| **Service monitoring + Amazon DevOps Guru** | Explicit alarm thresholds and anomaly bands you define | ML-driven anomaly detection across related resources that you didn't explicitly instrument |
+| **Service monitoring + AWS Trusted Advisor** | Real-time operational health | Periodic checks for quota utilization, security, and cost optimization |
+| **Service monitoring + Notifications** | Metric collection and alarm evaluation | Alert routing, escalation, and on-call integration (see [Notifications](notifications.md)) |
+
+## Documentation
+
+<div class="grid cards" markdown>
+
+*   :material-file-document: **CloudWatch cross-account observability**
+
+    ---
+
+    Set up a centralized monitoring account to view metrics, logs, and traces across your AWS Organization.
+
+    [:octicons-arrow-right-24: Documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch-Unified-Cross-Account.html)
+
+*   :material-file-document: **CloudWatch anomaly detection**
+
+    ---
+
+    Configure ML-based anomaly detection alarms that adapt to changing traffic patterns without manual threshold tuning.
+
+    [:octicons-arrow-right-24: Documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Anomaly_Detection.html)
+
+*   :material-file-document: **CloudWatch composite alarms**
+
+    ---
+
+    Combine multiple alarm states into a single composite alarm to reduce noise and alert only on confirmed problems.
+
+    [:octicons-arrow-right-24: Documentation](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Create_Composite_Alarm.html)
+
+*   :material-file-document: **EventBridge rules for CloudWatch alarms**
+
+    ---
+
+    Route alarm state changes to automated remediation actions through EventBridge rules.
+
+    [:octicons-arrow-right-24: Documentation](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-service-event.html)
+
+*   :material-currency-usd: **CloudWatch pricing**
+
+    ---
+
+    Understand the cost model for metrics, alarms, dashboards, and cross-account observability.
+
+    [:octicons-arrow-right-24: Pricing](https://aws.amazon.com/cloudwatch/pricing/)
+
+*   :material-file-document: **AWS Service Quotas**
+
+    ---
+
+    Monitor service quota utilization with CloudWatch integration and request increases before hitting limits.
+
+    [:octicons-arrow-right-24: Documentation](https://docs.aws.amazon.com/servicequotas/latest/userguide/intro.html)
+
+</div>
+
+## Related Observability Pages
+
+- **[Internal Traffic Monitoring](internal-traffic.md)** — Covers VPC Flow Logs and traffic mirroring for understanding what's flowing through your network, complementing the service health view on this page.
+- **[External Traffic Monitoring](external-traffic.md)** — Covers monitoring traffic between AWS and the internet, including CloudFront and edge service metrics.
+- **[Notifications](notifications.md)** — Covers alert routing, escalation policies, and integration with incident management tools. Service monitoring generates the signals; notifications deliver them to the right people.
+
+**Relationship to other sections:**
+
+- **[Connectivity Within AWS](../connectivity/within-aws.md)**: Covers the Transit Gateway, Cloud WAN, and VPC Peering services that this page monitors.
+- **[Hybrid & Multi-Cloud](../connectivity/hybrid-multicloud.md)**: Covers Direct Connect and Site-to-Site VPN architecture; this page covers their operational monitoring.
+- **[Load Balancing](../application-networking/load-balancing.md)**: Covers ALB, NLB, and GWLB architecture and best practices; this page covers their health metrics and alarms.


### PR DESCRIPTION
# 📝 Description

Add the complete Observability section (internal traffic monitoring, external traffic monitoring, AWS services monitoring, notifications) with deeply opinionated best practices following the project's content conventions.

## What Changed

**Observability section — new content (4 sub-pages + index):**

- `observability/index.md` — Section overview with numbered summaries and grid cards, matching the Foundation/Connectivity/Application Networking/Security index style
- `observability/internal-traffic.md` (424 lines) — VPC Flow Logs as the foundation, Transit Gateway Flow Logs for cross-VPC visibility, VPC Lattice access logs, Network Firewall logs, custom log format guidance, S3 vs CloudWatch Logs delivery trade-offs, Athena integration with partition projection, multi-account centralized log aggregation, IPv6 traffic visibility, and cost optimization (aggregation intervals, Parquet conversion)
- `observability/external-traffic.md` (401 lines) — Layered external observability (edge → WAF → LB → VPC), CloudFront standard and real-time logs, ALB/NLB access logs, WAF logs, NAT Gateway metrics for egress cost visibility, Route 53 query logs, Global Accelerator flow logs, client experience monitoring (latency percentiles, cache hit ratios), IPv6 client adoption tracking, multi-account logging architecture, and cost management
- `observability/service-monitoring.md` (380 lines) — Critical CloudWatch metrics for 9 networking services (Transit Gateway, NAT Gateway, Direct Connect, Site-to-Site VPN, ALB, NLB, Network Firewall, Route 53 Resolver, VPC Lattice) with specific alarm thresholds, composite alarms to reduce noise, anomaly detection, quota monitoring, centralized cross-account dashboards, IPv6/dual-stack monitoring, cost-effective monitoring patterns, and automated remediation with EventBridge
- `observability/notifications.md` (309 lines) — Alarm design principles (signal over noise), composite alarms for alert fatigue prevention, severity tiers with distinct routing, EventBridge for state-change notifications, cross-account event forwarding, AWS Health events, AWS Chatbot integration, automated remediation patterns, and notification cost awareness

## Why This Change

The Observability section was listed in the site navigation (`mkdocs.yml`) but all four sub-pages contained only "Content coming soon" placeholders. This PR fills them with production-quality content that follows the same conventions as the existing Foundation, Connectivity, Application Networking, and Security sections — including prerequisites admonitions, mermaid diagrams, grid card documentation links, `***Key insight:***` callouts, IPv6 coverage, multi-account context, and cost implications.

**Related issue/discussion:**
N/A — completing the Observability pillar referenced in the site's architecture overview.

# Checklist:

Tick the boxes before submitting:

## 🔄 Type of Change

- [x] New content
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing

- [ ] Ran `./scripts/validate-pr.sh` locally
- [ ] Checked for broken internal links
- [ ] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards

- [x] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [x] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
