### PR TITLE
Limit table of contents depth to H3

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -99,6 +99,7 @@ extra:
 markdown_extensions:
   - toc:
       permalink: true
+      toc_depth: 3
   - admonition
   - abbr
   - codehilite


### PR DESCRIPTION
# 📝 Description

Limit the page table of contents to H3 depth, hiding H4 headings from the right-side navigation.

## What Changed

- `mkdocs.yml` — Added `toc_depth: 3` to the `toc` markdown extension configuration

## Why This Change

Our content structure uses H4 (`####`) for individual best practice titles (for example, "Start with /16 for production VPCs and never go smaller than /20"). On long pages like the VPC or Connectivity Within AWS pages, these H4 headings inflate the table of contents to 30+ entries, making it difficult to scan for major sections.

With `toc_depth: 3`, the TOC shows:
- H2: Major sections (Best Practices, When to use, Documentation)
- H3: Practice categories (CIDR sizing and planning, IPv6 adoption)

And hides:
- H4: Individual practices (these are still reachable by scrolling within their H3 category)

This matches the intent of our heading hierarchy: H2 and H3 are navigational landmarks, H4 is content-level structure within a category.

**Related issue/discussion:**
N/A — usability improvement for page navigation on long content pages.

# Checklist:

Tick the boxes before submitting:

## 🔄 Type of Change

- [ ] New content
- [ ] Bug fix
- [x] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing

- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [x] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards

- [x] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [x] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
