### PR TITLE
Clean up navigation: hide sidebar site name, remove breadcrumbs

### DIFF
--- a/content/stylesheets/extra.css
+++ b/content/stylesheets/extra.css
@@ -42,3 +42,8 @@
 }
 
 /* END: Custom admonition for services styling with material icons */
+
+/* Hide redundant site name from sidebar navigation (it duplicates the header) */
+.md-nav__title[for="__drawer"] {
+  display: none;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,7 +63,6 @@ theme:
     - navigation.tracking
     - navigation.indexes
     - navigation.expand
-    - navigation.path
     - navigation.footer
 
 # Additional configuration


### PR DESCRIPTION
# 📝 Description

Clean up two navigation elements that add visual noise without helping orientation.

## What Changed

- **`content/stylesheets/extra.css`**: Hide the site name from the sidebar nav via CSS. It's non-clickable static text that duplicates the header and sits directly above "Introduction."
- **`mkdocs.yml`**: Remove the `navigation.path` (breadcrumbs) feature. With a 2-level nav structure, breadcrumbs only ever display the section name — which is already visible in the sidebar.

## Why This Change

The site name in the sidebar is redundant (same text as the header, not a link). The breadcrumbs don't include second-level pages like "Internet" — they only show the top-level section, which adds no value over what the sidebar already provides. Removing both reduces clutter without losing any navigational utility.

# Checklist:

## 🔄 Type of Change

- [ ] New content
- [x] Bug fix
- [ ] Documentation update
- [x] Refactoring/reorganization

## 🧪 Testing

- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [x] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards

- [x] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [x] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.