### PR TITLE
Fix dead link in organizations.md documentation section

### DIFF
--- a/content/foundation/organizations.md
+++ b/content/foundation/organizations.md
@@ -237,9 +237,9 @@ Organizations is the governance layer that enables every other multi-account net
 
     ---
 
-    Prescriptive guidance for setting up multi-account environments with networking, security, and governance foundations.
+    Automate account creation by using the Landing Zone Accelerator on AWS.
 
-    [:octicons-arrow-right-24: Guide](https://docs.aws.amazon.com/prescriptive-guidance/latest/migration-aws-environment/building-landing-zones.html)
+    [:octicons-arrow-right-24: Guide](https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/automate-account-creation-lza.html)
 
 *   :material-share-variant: **AWS Resource Access Manager**
 


### PR DESCRIPTION
# 📝 Description

The "Building Landing Zones" card in the Documentation section linked to `building-landing-zones.html` which returns a 404. Replaced with the active AWS prescriptive guidance page for automating account creation with the Landing Zone Accelerator on AWS. The description was updated to match the new target page.
# Checklist:
Tick the boxes before submitting: 

## 🔄 Type of Change
- [ ] New content
- [ ] Bug fix
- [X] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing
- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [X] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards
- [X] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [X] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.