### PR TITLE
Update GitHub Actions to Node.js 24-compatible versions actions/checkout v4→v5, actions/cache v4→v5, dorny/paths-filter v2→v3. Resolves Node.js 20 deprecation warnings on GitHub Actions runners.

### DIFF
--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -12,7 +12,7 @@ jobs:
     # Only run in the main repository, not in forks
     if: github.repository == 'aws/aws-networking-best-practices'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Configure Git Credentials
@@ -20,7 +20,7 @@ jobs:
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
       - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV 
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           key: mkdocs-material-${{ env.cache_id }}
           path: .cache

--- a/.github/workflows/pr-guidelines.yml
+++ b/.github/workflows/pr-guidelines.yml
@@ -14,7 +14,7 @@ jobs:
   check-guidelines:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - name: Check multiple markdown files

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,10 +16,10 @@ jobs:
     outputs:
       docs: ${{ steps.changes.outputs.docs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: dorny/paths-filter@v2
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: |
@@ -33,7 +33,7 @@ jobs:
     if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: DavidAnson/markdownlint-cli2-action@v16
         with:
           globs: 'content/**/*.md'
@@ -44,7 +44,7 @@ jobs:
     if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
       - uses: ./.github/actions/setup-mkdocs
@@ -56,7 +56,7 @@ jobs:
     if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           use-quiet-mode: 'yes'
@@ -69,7 +69,7 @@ jobs:
     if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: streetsidesoftware/cspell-action@v6
         with:
           files: 'content/**/*.md'
@@ -80,7 +80,7 @@ jobs:
     if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ibiqlik/action-yamllint@v3
         with:
           file_or_dir: mkdocs.yml
@@ -91,7 +91,7 @@ jobs:
     if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check file naming conventions
         run: |
           # Check for spaces in filenames
@@ -112,7 +112,7 @@ jobs:
     if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check image optimization
         run: |
           # Find large images (>500KB)
@@ -135,7 +135,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version: '18'
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Validate navigation structure
         run: |
           # Check that all markdown files are referenced in mkdocs.yml
@@ -215,7 +215,7 @@ jobs:
     if: needs.changes.outputs.docs == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Validate IP addresses
         run: |
           python3 << 'EOF'
@@ -311,7 +311,7 @@ jobs:
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check page metadata
         run: |
           echo "Checking for proper page titles..."


### PR DESCRIPTION
# 📝 Description

Update GitHub Actions to Node.js 24-compatible versions to resolve deprecation warnings. Node.js 20 is deprecated on GitHub Actions runners as of September 2025, and workflows using actions that target Node.js 20 now emit forced-execution warnings.

## What Changed

- `.github/workflows/gh-pages-deploy.yml` — `actions/checkout` v4→v5, `actions/cache` v4→v5
- `.github/workflows/pr-validation.yml` — `actions/checkout` v4→v5, `dorny/paths-filter` v2→v3
- `.github/workflows/pr-guidelines.yml` — `actions/checkout` v4→v5

## Why This Change

GitHub is deprecating Node.js 20 on Actions runners. Affected actions are currently force-run on Node.js 24 with warnings, but will eventually fail. Updating to the latest major versions ensures continued CI operation without deprecation noise.

# Checklist:

## 🔄 Type of Change

- [ ] New content
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing

- [X] Ran `./scripts/validate-pr.sh` locally
- [X] Checked for broken internal links
- [x] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards

- [x] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [x] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.