### PR TITLE
Fix site_url and add robots.txt + Google site verification file

### DIFF
--- a/content/google4beddda51c839393.html
+++ b/content/google4beddda51c839393.html
@@ -1,0 +1,1 @@
+google-site-verification: google4beddda51c839393.html

--- a/content/robots.txt
+++ b/content/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://aws.github.io/aws-networking-best-practices/sitemap.xml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 ---
 # Project information
 site_name: Networking Best Practices
-site_url: https://aws.github.io/aws/aws-networking-best-practices/
+site_url: https://aws.github.io/aws-networking-best-practices/
 site_description: >-
   AWS Networking Architecture guidance and best practices by the AWS user
   community, vetted by AWS Networking Specialist.


### PR DESCRIPTION
# 📝 Description

Fix a broken sitemap URL and add the files needed to register this site with Google Search Console and Bing Webmaster Tools.

## What Changed

- Fixed `site_url` in `mkdocs.yml` — it had a stray `/aws/` segment (`https://aws.github.io/aws/aws-networking-best-practices/`) that produced incorrect canonical URLs in the generated `sitemap.xml`.
- Added `content/robots.txt`, which allows all crawlers and points to `sitemap.xml`.
- Moved `google4beddda51c839393.html` (Google Search Console verification file) into `content/` so MkDocs publishes it at the site root (`/google4beddda51c839393.html`) instead of leaving it unpublished at the repo root.

## Why This Change

The incorrect `site_url` meant every URL in `sitemap.xml` pointed to a non-existent path, so the sitemap couldn't be submitted to Google Search Console or Bing Webmaster Tools. This fixes the base URL, adds `robots.txt` so crawlers can discover the sitemap without it being submitted manually, and publishes the Google verification file required to register the property.

**Related issue/discussion:**

N/A

# Checklist:

Tick the boxes before submitting:

## 🔄 Type of Change

- [x] Bug fix

## 🧪 Testing

- [x] Ran `./scripts/validate-pr.sh` locally
- [x] Checked for broken internal links
- [x] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards

- [x] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [x] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
