### PR TITLE
Update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/actions/setup-mkdocs/action.yml
+++ b/.github/actions/setup-mkdocs/action.yml
@@ -8,7 +8,7 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - uses: actions/setup-python@v5
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ inputs.python-version }}
     - name: Install MkDocs dependencies

--- a/.github/workflows/gh-pages-deploy.yml
+++ b/.github/workflows/gh-pages-deploy.yml
@@ -30,7 +30,7 @@ jobs:
       - run: mkdocs gh-deploy --force
       - name: Send GitHub Action data to a Slack workflow
         if: always()
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}
           webhook-type: webhook-trigger

--- a/.github/workflows/issue-notifications.yml
+++ b/.github/workflows/issue-notifications.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send issue notification to Slack
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_ISSUES }}
           webhook-type: webhook-trigger

--- a/.github/workflows/markdown-preview.yml
+++ b/.github/workflows/markdown-preview.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Generate markdown preview
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Fetch the list of changed files from the PR via API (no untrusted checkout)

--- a/.github/workflows/pr-guidelines.yml
+++ b/.github/workflows/pr-guidelines.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check multiple markdown files
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const { execSync } = require('child_process');

--- a/.github/workflows/pr-notification.yml
+++ b/.github/workflows/pr-notification.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Send PR notification to Slack
-        uses: slackapi/slack-github-action@v2.0.0
+        uses: slackapi/slack-github-action@v4.0.0
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL_NEWPR }}
           webhook-type: webhook-trigger

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: changes
         with:
           filters: |
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: DavidAnson/markdownlint-cli2-action@v16
+      - uses: DavidAnson/markdownlint-cli2-action@v24
         with:
           globs: 'content/**/*.md'
           config: '.github/.markdownlint-cli2.yaml'
@@ -70,7 +70,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - uses: streetsidesoftware/cspell-action@v6
+      - uses: streetsidesoftware/cspell-action@v8
         with:
           files: 'content/**/*.md'
           config: '.github/cspell.json'
@@ -136,7 +136,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v5
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '18'
       - name: Install prose linting tools

--- a/content/community/new-best-practice.md
+++ b/content/community/new-best-practice.md
@@ -61,7 +61,7 @@ A good title is short and descriptive. It should be a one-sentence executive
 summary of the idea, so the potential impact and benefit for our community can
 be inferred from the title.
 
-| <!-- --> | Example  |
+| <!-- --> | Example |
 | -------- | -------- |
 | :material-check:{ style="color: #4DB6AC" } **Clear** | SD-WAN integration with TGW |
 | :material-close:{ style="color: #EF5350" } **Wordy** | Add a feature where you describe how to integrate various SD-WAN options with a Transit Gateway |

--- a/content/community/report-a-correction.md
+++ b/content/community/report-a-correction.md
@@ -23,7 +23,7 @@ A good title should be a short, one-sentence description of the issue, contain
 all relevant information and, in particular, keywords to simplify the search in
 our issue tracker.
 
-| <!-- --> | Example  |
+| <!-- --> | Example |
 | -------- | -------- |
 | :material-check:{ style="color: #4DB6AC" } **Clear** | Clarify the use of DX for multi cloud scenarios |
 | :material-close:{ style="color: #EF5350" } **Unclear** | Missing information in the docs |

--- a/content/decisions.md
+++ b/content/decisions.md
@@ -18,9 +18,9 @@ This page maps common AWS networking questions to the right service, pattern, an
 | I need to... | Recommended pattern | Key trade-off | Learn more |
 | --- | --- | --- | --- |
 | Let private IPv4 resources reach the internet | **NAT gateway** - Zonal or Regional, resilient and scales automatically | Data processing and hourly cost if not centralized | [Internet Connectivity](connectivity/internet.md) |
-| Let private IPv6 resources reach the internet | **Egress-only internet gateway** — no data process (data transfer still applies), per-VPC, outbound-only | Cannot be centralized; doesn't support NAT66/NPTv6  | [Internet Connectivity](connectivity/internet.md) |
+| Let private IPv6 resources reach the internet | **Egress-only internet gateway** — no data process (data transfer still applies), per-VPC, outbound-only | Cannot be centralized; doesn't support NAT66/NPTv6 | [Internet Connectivity](connectivity/internet.md) |
 | Expose an HTTP/HTTPS application to the internet | **CloudFront + AWS WAF + ALB** (decentralized ingress) — edge caching, L7 protection, VPC Origins for private backends | Centralized ingress through a shared VPC adds load-balancer chaining and blast radius; avoid unless compliance mandates it | [Internet Connectivity](connectivity/internet.md) |
-| Expose a TCP/UDP service to the internet | **NLB** internet-facing, per-VPC, can preserve client IP | Combine with security groups or Next Generation Firewall for additional security| [Internet Connectivity](connectivity/internet.md) |
+| Expose a TCP/UDP service to the internet | **NLB** internet-facing, per-VPC, can preserve client IP | Combine with security groups or Next Generation Firewall for additional security | [Internet Connectivity](connectivity/internet.md) |
 | Reduce NAT gateway costs for traffic to AWS Services | **VPC Endpoints** — gateway endpoints for S3/DynamoDB (free), interface endpoints for other services | Interface endpoints have hourly and data processing charges; | [Internet Connectivity](connectivity/internet.md) |
 
 ## Connecting to on-premises and other clouds

--- a/content/foundation/aws-prerequisites.md
+++ b/content/foundation/aws-prerequisites.md
@@ -48,7 +48,7 @@ AWS imposes default limits on networking resources, and many of them are lower t
 **Quotas that catch networking teams most often:**
 
 | Resource | Default Limit | Why It Matters |
-|----------|:---:|---|
+| ---------- | :---: | --- |
 | VPCs per Region | 5 | Multi-account environments hit this quickly in shared-services accounts |
 | Subnets per VPC | 200 | Rarely an issue, but large multi-AZ designs with many tiers can approach it |
 | Routes per route table | 50 | Transit Gateway and VPC peering each consume a route entry per destination |

--- a/content/foundation/cidr.md
+++ b/content/foundation/cidr.md
@@ -30,12 +30,12 @@ The prefix length determines how many addresses the block contains: a `/16` has 
 ### Common CIDR Block Sizes
 
 | CIDR | Addresses | Usable in Subnet* | Typical Use |
-|------|-----------|-------------------|-------------|
-| /16  | 65,536    | 65,531            | Large VPC for enterprise environments, gives maximum room for subnets |
-| /20  | 4,096     | 4,091             | Medium VPC, departmental or single-workload VPCs |
-| /24  | 256       | 251               | Standard subnet size, balances density with manageability |
-| /26  | 64        | 59                | Smaller subnets for firewall endpoints, NAT gateway, or TGW attachments |
-| /28  | 16        | 11                | Minimum VPC or subnet size, used for specific services only |
+| --- | --- | --- | --- |
+| /16 | 65,536 | 65,531 | Large VPC for enterprise environments, gives maximum room for subnets |
+| /20 | 4,096 | 4,091 | Medium VPC, departmental or single-workload VPCs |
+| /24 | 256 | 251 | Standard subnet size, balances density with manageability |
+| /26 | 64 | 59 | Smaller subnets for firewall endpoints, NAT gateway, or TGW attachments |
+| /28 | 16 | 11 | Minimum VPC or subnet size, used for specific services only |
 
 *AWS reserves 5 IP addresses in each subnet (first four and last one).
 
@@ -44,7 +44,7 @@ The prefix length determines how many addresses the block contains: a `/16` has 
 These are the private IP ranges available for your VPCs:
 
 | Range | CIDR | Addresses | Recommendation |
-|-------|------|-----------|----------------|
+| ------- | ------ | ----------- | ---------------- |
 | 10.0.0.0 – 10.255.255.255 | 10.0.0.0/8 | 16,777,216 | **Preferred for most organizations.** Largest contiguous space, supports deep hierarchical allocation. |
 | 172.16.0.0 – 172.31.255.255 | 172.16.0.0/12 | 1,048,576 | Good secondary range. Often already used by on-premises networks. |
 | 192.168.0.0 – 192.168.255.255 | 192.168.0.0/16 | 65,536 | Avoid for production AWS use. Too small for multi-account environments and commonly used by home networks and VPN clients, causing overlap issues. |
@@ -122,7 +122,7 @@ Assign each Region a dedicated block within your organizational allocation. This
 **Example multi-Region scheme** (within `10.0.0.0/9` for AWS):
 
 | Region | CIDR Block | Purpose |
-|--------|-----------|---------|
+| -------- | ----------- | --------- |
 | us-east-1 | 10.0.0.0/12 | Primary Region |
 | us-west-2 | 10.16.0.0/12 | DR / Secondary |
 | eu-west-1 | 10.32.0.0/12 | European workloads |
@@ -148,7 +148,7 @@ IPv6 in AWS VPCs works differently from IPv4 and requires separate planning:
 **IPv6 CIDR source options:**
 
 | Source | Use Case | Consideration |
-|--------|----------|---------------|
+| -------- | ---------- | --------------- |
 | Amazon-provided | Default for most workloads | Addresses are assigned from Amazon's pool; change if you disassociate |
 | BYOIP (Bring Your Own IP) | Enterprises with existing IPv6 allocations | Requires RIR registration and ROA; provides address portability |
 | IPAM-managed Amazon pool | Multi-account with consistent allocation | Allocates from Amazon's pool but through IPAM for governance |
@@ -178,7 +178,7 @@ Secondary CIDRs are **not** a substitute for proper initial planning. They add c
 #### Avoid common CIDR planning mistakes
 
 | Mistake | Why It Hurts | Prevention |
-|---------|-------------|------------|
+| --------- | ------------- | ------------ |
 | Using `192.168.0.0/16` for production | Overlaps with home networks, VPN clients, and many on-premises environments | Use `10.0.0.0/8` for AWS production |
 | Allocating `/24` VPCs "to save space" | Exhausts subnet capacity quickly; no room for multi-AZ or EKS | Default to `/16` for production, `/20` minimum for non-production |
 | No reserved space for future Regions | Forces non-contiguous allocation when expanding | Reserve 50%+ of your total allocation |
@@ -193,7 +193,7 @@ CIDR planning is not an isolated activity — it directly enables or constrains 
 The table below shows how CIDR decisions interact with key AWS networking services.
 
 | Combination | CIDR Planning Enables | Other Service Provides |
-|---|---|---|
+| --- | --- | --- |
 | **CIDR + IPAM** | Hierarchical allocation scheme, size standards, reserved ranges | Automated allocation enforcement, overlap prevention, compliance auditing, multi-account governance |
 | **CIDR + Transit Gateway** | Non-overlapping VPC ranges that can share route tables; contiguous blocks for route summarization | Regional hub-and-spoke routing, centralized egress, shared services connectivity |
 | **CIDR + Direct Connect / Hybrid** | AWS ranges that never overlap with on-premises; summarizable blocks for BGP advertisements | Private dedicated connectivity, predictable bandwidth, reduced data transfer costs |
@@ -214,7 +214,7 @@ Every subnet consumes a contiguous portion of the VPC CIDR. AWS reserves 5 addre
 **Recommended subnet layout for a `/16` VPC across 3 Availability Zones:**
 
 | Subnet Tier | AZ-A | AZ-B | AZ-C | Size | Purpose |
-|-------------|------|------|------|------|---------|
+| ------------- | ------ | ------ | ------ | ------ | --------- |
 | Public | 10.0.0.0/24 | 10.0.1.0/24 | 10.0.2.0/24 | /24 (251 usable) | Load balancers, NAT gateways, bastion hosts |
 | Private (application) | 10.0.10.0/24 | 10.0.11.0/24 | 10.0.12.0/24 | /24 (251 usable) | Application servers, containers, Lambda |
 | Private (data) | 10.0.20.0/24 | 10.0.21.0/24 | 10.0.22.0/24 | /24 (251 usable) | RDS, ElastiCache, OpenSearch |

--- a/scripts/validate-pr.sh
+++ b/scripts/validate-pr.sh
@@ -11,18 +11,30 @@ if [ ! -f "mkdocs.yml" ]; then
     exit 1
 fi
 
+# Tool versions pinned to match the underlying CLI versions used by the
+# corresponding GitHub Actions in .github/workflows/pr-validation.yml.
+# Using npx with these pins (instead of whatever is globally installed)
+# ensures local runs actually reproduce CI results. When bumping an
+# action's version in the workflow, update the matching pin here too.
+#   - markdownlint-cli2-action@v24.2.0 -> markdownlint-cli2@0.23.2
+#   - cspell-action@v8.4.0             -> cspell@9.8.0
+#   - github-action-markdown-link-check@1.0.17 -> markdown-link-check@3.13.7
+MARKDOWNLINT_CLI2_VERSION="0.23.2"
+CSPELL_VERSION="9.8.0"
+MARKDOWN_LINK_CHECK_VERSION="3.13.7"
+
 ERRORS=0
 FAILED_CHECKS=()
 
 # Markdown lint
 echo "📝 Checking markdown lint..."
-if command -v markdownlint-cli2 &> /dev/null; then
-    if ! markdownlint-cli2 --config .github/.markdownlint-cli2.yaml "content/**/*.md"; then
+if command -v npx &> /dev/null; then
+    if ! npx --yes "markdownlint-cli2@${MARKDOWNLINT_CLI2_VERSION}" --config .github/.markdownlint-cli2.yaml "content/**/*.md"; then
         FAILED_CHECKS+=("Markdown lint")
         ERRORS=$((ERRORS+1))
     fi
 else
-    echo "❌ markdownlint-cli2 not installed. Install with: npm install -g markdownlint-cli2"
+    echo "❌ npx not found. Install Node.js (which bundles npx) to run this check."
     exit 1
 fi
 
@@ -40,27 +52,27 @@ fi
 
 # Link check
 echo "🔗 Checking links..."
-if command -v markdown-link-check &> /dev/null; then
-    find content -name "*.md" -exec markdown-link-check --config .github/mlc_config.json {} \; | tee /tmp/link_check.log
+if command -v npx &> /dev/null; then
+    find content -name "*.md" -exec npx --yes "markdown-link-check@${MARKDOWN_LINK_CHECK_VERSION}" --config .github/mlc_config.json {} \; | tee /tmp/link_check.log
     if grep -q "ERROR:" /tmp/link_check.log; then
         echo "❌ Dead links found"
         FAILED_CHECKS+=("Link check")
         ERRORS=$((ERRORS+1))
     fi
 else
-    echo "❌ markdown-link-check not installed. Install with: npm install -g markdown-link-check"
+    echo "❌ npx not found. Install Node.js (which bundles npx) to run this check."
     exit 1
 fi
 
 # Spell check
 echo "📖 Checking spelling..."
-if command -v cspell &> /dev/null; then
-    if ! cspell --config .github/cspell.json "content/**/*.md"; then
+if command -v npx &> /dev/null; then
+    if ! npx --yes "cspell@${CSPELL_VERSION}" --config .github/cspell.json "content/**/*.md"; then
         FAILED_CHECKS+=("Spell check")
         ERRORS=$((ERRORS+1))
     fi
 else
-    echo "❌ cspell not installed. Install with: npm install -g cspell"
+    echo "❌ npx not found. Install Node.js (which bundles npx) to run this check."
     exit 1
 fi
 


### PR DESCRIPTION
# 📝 Description

Several actions in the workflows were still pinned to versions that run on the deprecated Node.js 20 runtime. GitHub Actions runners now force these to run under Node.js 24 with a deprecation warning, and Node.js 20 support will be fully removed later this year.

## What Changed

Bumped the following actions to Node.js 24-compatible versions:

- `actions/setup-python` v5 -> v7 (setup-mkdocs composite action)
- `slackapi/slack-github-action` v2.0.0 -> v4.0.0 (gh-pages-deploy, issue-notifications, pr-notification)
- `actions/github-script` v7 -> v9 (markdown-preview, pr-guidelines)
- `actions/setup-node` v4 -> v5 (pr-validation prose-check job)
- `DavidAnson/markdownlint-cli2-action` v16 -> v24 (pr-validation)
- `dorny/paths-filter` v3 -> v4 (pr-validation)
- `streetsidesoftware/cspell-action` v6 -> v8 (pr-validation)

Pinned `cspell-action` to v8 rather than the latest v9, since v9 bumps the underlying CSpell engine to a new major version that could introduce unrelated spelling false positives.

`actions/checkout@v5` and `actions/cache@v5` were already on Node.js 24 and left unchanged. `gaurav-nelson/github-action-markdown-link-check` (Docker-based) and `ibiqlik/action-yamllint` (composite/bash) are not JavaScript actions and are unaffected by this deprecation.

## Why This Change

GitHub Actions runners now force actions pinned to Node.js 20 to run under Node.js 24 anyway, but emit a deprecation warning on every run. Node.js 20 will be fully removed from runners later this year, at which point unmigrated actions would break outright. This updates all affected actions ahead of that deadline.

**Related issue/discussion:**

N/A

# Checklist:

Tick the boxes before submitting:

## 🔄 Type of Change

- [ ] New content
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring/reorganization

## 🧪 Testing

- [x] Ran `./scripts/validate-pr.sh` locally
- [x] Checked for broken internal links
- [x] Tested MkDocs build and preview looks correct locally

## 📋 Quality & Standards

- [x] My submission follows the [philosophy](https://aws.github.io/aws-networking-best-practices/community/philosophy/) of this project
- [x] My submission follows the [conventions](https://aws.github.io/aws-networking-best-practices/community/conventions/) of this project

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
